### PR TITLE
dhcpv6-yang-05

### DIFF
--- a/ietf-dhcpv6-client@2017-11-24.yang
+++ b/ietf-dhcpv6-client@2017-11-24.yang
@@ -13,7 +13,7 @@ module ietf-dhcpv6-client {
   }
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-11-24";
+    revision-date "2017-12-22";
   }
 
   organization "DHC WG";
@@ -21,21 +21,21 @@ module ietf-dhcpv6-client {
     wangh13@mails.tsinghua.edu.cn
     lh.sunlinh@gmail.com
     ian.farrer@telekom.de
-    sladjana.zechlin@telekom.de";
+    sladjana.zechlin@telekom.de
+    hezihao9512@gmail.com  ";
 
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 client.";
 
-	
-  revision 2017-11-29{
-	  description "First version of the seperation of Configuration
-		  and State trees.";
+  revision 2017-12-22 {
+	  description "Resolve most issues on Ian's github.";
 	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
   
   revision 2017-11-24 {
 	    description "First version of the separated client specific
 	      YANG model.";
+	    reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
   
   /*
@@ -59,57 +59,79 @@ module ietf-dhcpv6-client {
   }
 
   grouping duid {
-    description "DHCP Unique Identifier";
-    reference "RFC3315: Section 9";
-    choice duid-type {
-      description "Selects the format for the DUID.";
-      case duid-llt {
-        description "DUID Based on Link-layer Address Plus Time";
-        reference "RFC3315 Section 9.2";
-        leaf duid-llt-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
+	    description "DHCP Unique Identifier";
+	    reference "RFC3315: Section 9";
+	    leaf type-code {
+        	type uint16;
+        	default 65535;
+        	description "Type code of this DUID";
         }
-        leaf duid-llt-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-                        modulo 2^32.";
-        }
-        leaf duid-llt-link-layer-addr {
-          type yang:mac-address;
-          description "Link-layer address as described in RFC2464";
-        }
-      }
-      case duid-en {
-        description "DUID Assigned by Vendor Based on Enterprise Number";
-        reference "RFC3315 Section 9.3";
-        leaf duid-en-enterprise-number {
-          type uint32;
-          description "Vendor's registered Private Enterprise Number as
-            maintained by IANA";
-        }
-        leaf duid-en-identifier {
-          type string;
-          description "Indentifier, unique to the device that is using it";
-        }
-      }
-      case duid-ll {
-        description "DUID Based on Link-layer Address";
-        reference "RFC3315 Section 9.4";
-        leaf duid-ll-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
-        }
-        leaf duid-ll-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-            modulo 2^32.";
-        }
-      }
-    }
-  }
+	    choice duid-type {
+		  default duid-invalid;
+	      description "Selects the format for the DUID.";
+	      case duid-llt {
+	        description "DUID Based on Link-layer Address Plus Time (Type 1 - DUID-LLT)";
+	        reference "RFC3315 Section 9.2";
+
+	        leaf duid-llt-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-llt-time {
+	          type yang:timeticks;
+	          description "The time value is the time that the DUID is generated
+	            represented in seconds since midnight (UTC), January 1, 2000,
+	                        modulo 2^32.";
+	        }
+	        leaf duid-llt-link-layer-addr {
+	          type yang:mac-address;
+	          description "Link-layer address as described in RFC2464";
+	        }
+	      }
+	      case duid-en {
+	        description "DUID Assigned by Vendor Based on Enterprise Number (Type 2 - DUID-EN)";
+	        reference "RFC3315 Section 9.3";
+	        leaf duid-en-enterprise-number {
+	          type uint32;
+	          description "Vendor's registered Private Enterprise Number as
+	            maintained by IANA";
+	        }
+	        leaf duid-en-identifier {
+	          type string;
+	          description "Indentifier, unique to the device that is using it";
+	        }
+	      }
+	      case duid-ll {
+	        description "DUID Based on Link-layer Address (Type 3 - DUID-LL)";
+	        reference "RFC3315 Section 9.4";
+	        leaf duid-ll-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-ll-link-layer-addr {
+		          type yang:mac-address;
+		          description "Link-layer address as described in RFC2464";
+		    }
+	      }
+	      case duid-uuid {
+	    	  description "DUID Based on Universally Unique Identifier (Type 4 - DUID-UUID)";
+	    	  reference "RFC6335 Defination of the UUID-Based Unique Identifier";
+	    	  leaf uuid {
+	    		  type yang:uuid;
+	    		  description "A Universally Unique IDentifier in the string representation
+	    		      defined in RFC 4122.  The canonical representation uses
+	    		      lowercase characters";
+	    	  }    	  
+	      }
+	      case duid-invalid {
+	    	  description "DUID based on free raw bytes";
+	    	  leaf data {
+	    		  type binary;
+	    		  description "The bits to be used as the identifier";
+	    	  }
+	      }	      
+	    }
+	  }
   grouping portset-para {
     description "portset parameters";
     container port-parameter {
@@ -133,14 +155,12 @@ module ietf-dhcpv6-client {
   }
 
   grouping iaid {
-    container identity-associations {
-      config "false";
-      description "IA is a construct through which a server and a
-        client can identify, group, and manage a set of related IPv6
-        addresses. The key of the list is a 4-byte number IAID defined
-        in [RFC3315].";
+	  description "IA is a construct through which a server and a
+	      client can identify, group, and manage a set of related IPv6
+	      addresses. The key of the list is a 4-byte number IAID defined
+	      in [RFC3315].";
       list identity-association {
-        key iaid;
+        config "false";
         description "IA";
         leaf iaid {
           type uint32;
@@ -185,7 +205,7 @@ module ietf-dhcpv6-client {
           description "valid lifetime";
         }
       }
-    }
+    
   }
 
   /*
@@ -193,11 +213,10 @@ module ietf-dhcpv6-client {
    */
 
  container client {
+	presence "Enables the client";
     description "dhcpv6 client portion";
-    
     container client-config{
     	description "configuration tree of client";
-    	
         container duid {
             description "Sets the DUID";
             uses duid;
@@ -278,9 +297,8 @@ module ietf-dhcpv6-client {
     }
     
     container client-state{
-    	description "state tree of client";
-    	
     	config "false";
+    	description "state tree of client";
         container if-other-paras {
             description "A client can obtain
               extra configuration data other than
@@ -291,27 +309,6 @@ module ietf-dhcpv6-client {
               include DNS server addresses, SIP
               server domain names, etc.";
             uses dhcpv6-options:server-option-definitions;
-
-            container supported-options {
-              // if - Unclear on what this container is used for. Maybe
-              // putting options as 'features' could replace this.
-              description "supported options";
-              list supported-option {
-                key option-code;
-                description "supported option";
-                leaf option-code {
-                  type uint16;
-                  mandatory true;
-                  description "option code";
-                }
-                leaf description {
-                  type string;
-                  mandatory true;
-                  description
-                    "description of supported option";
-                }
-              }
-            }
           }
     }
   }
@@ -321,6 +318,7 @@ module ietf-dhcpv6-client {
    */
 
   notification notifications {
+	description "dhcpv6 client notification module";
     container dhcpv6-client-event {
       description "dhcpv6 client event";
       container ia-lease-event {

--- a/ietf-dhcpv6-options@2017-11-24.yang
+++ b/ietf-dhcpv6-options@2017-11-24.yang
@@ -1,4 +1,5 @@
 module ietf-dhcpv6-options {
+  yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-dhcpv6-options";
   prefix "dhcpv6-options";
 
@@ -16,11 +17,17 @@ module ietf-dhcpv6-options {
     wangh13@mails.tsinghua.edu.cn
     lh.sunlinh@gmail.com
     ian.farrer@telekom.de
-    sladjana.zechlin@telekom.de";
+    sladjana.zechlin@telekom.de
+    hezihao9512@gmail.com";
 
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 server.";
-
+  
+  revision 2017-12-22 {
+	  description "Resolve most issues on Ian's github.";
+	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
+  }
+  
   revision 2017-11-24 {
     description "First version of the separated DHCPv6 options
       YANG model.";
@@ -31,11 +38,17 @@ module ietf-dhcpv6-options {
   /*
    * Features
    */
+  
+  
+  //  features for server options
 	feature server-unicast-op {
 		description "Support for Server Unicast option";
 	}
-	feature sip-server-op {
-		description "Support for SIP Server option";
+	feature sip-server-domain-name-list-op {
+		description "Support for SIP Server Domain Name List option";
+	}
+	feature sip-server-address-list-op {
+		description "Support for SIP Server Address List option";
 	}
 	feature dns-config-op {
 		description "Support for DNS Recursive Name Server option";
@@ -51,113 +64,128 @@ module ietf-dhcpv6-options {
 		description "Support for Network Information Service V2 (NIS+) 
 			Servers option";
 	}
-  	feature nis-domain-name-op {
-  		description "Support for Network Information Service (NIS)
-  			Domain Name option";
-  	}
-  	feature nis-plus-domain-name-op {
-  		description "Support for Network Information Service V2 (NIS+)
-  			Server option";
-  	}
-  	feature sntp-server-op {
-  		description "Support for Simple Network Protocol Configuration 
-  			(SNTP) Servers option";
-  	}
-  	feature info-refresh-time-op {
-  		description "Support for Information Refresh Time option";
-  	}
-  	feature cli-fqdn-op {
-  		description "Support for Client FQDN option";
-  	}
-  	feature posix-timezone-op {
-  		description "Support for New POIX Timezone option";
-  	}
-  	feature tzdb-timezone-op {
-  		description "Support for New TZDB Timezone option";
-  	}
-  	feature ntp-server-op {
-  		description "Support for Network Time Protocol (NTP) 
-  			Server option";
-  	}
-  	feature network-boot-op {
-  		description "Support for Network Boot option";
-  	}
-  	feature aftr-name-op {
-  		description "Support for Address Family Transition
-  			Router (AFTR) option";
-  	}
-  	feature kerberos-op {
-  		description "Support for Kerberos options";
-  	}
-  	feature sol-max-rt-op {
-  		description "Support for SOL_MAX_RT option";
-  	}
-  	feature inf-max-rt-op {
-  		description "Support for INF_MAX_RT option";
-  	}
-  	feature addr-selection-op {
-  		description "Support for Address Selection opiton";
-  	}
-  	feature pcp-server-op {
-  		description "Support for Port Control Protocol (PCP)
-  			option";
-  	}
-  	feature s46-rule-op {
-  		description "Support for S46 Rule option";
-  	}
-  	feature s46-br-op {
-  		description "Support for S46 Border Relay (BR) option";
-  	}
-  	feature s46-dmr-op {
-  		description "Support for S46 Default Mapping Rule 
-  			(DMR) option";
-  	}
-  	feature s46-v4-v6-binding-op {
-  		description "Support for S46 IPv4/IPv6 Address
-  			Bind option";
-  	}
-  	feature erp-local-domain-name-op {
-  		description "Support for ERP Local Domain
-  			Name option";
-  	}
-  	feature option-request-op {
-  		description "Support for Option Request
-  			option";
-  	}
-  	feature rapid-commit-op {
-  		description "Support for Rapid Commit option";
-  	}
-  	feature user-class-op {
-  		description "Support for User Class option";
-  	}
-  	feature vendor-class-op {
-  		description "Support for Vendor Class option";
-  	}
-  	feature client-arch-type-op {
-  		description "Support for Client System Architecture
-  			Type option";
-  	}
-  	feature client-network-interface-identifier-op {
-  		description "Support for Client Network Interface
-  			Identifier option";
-  	}
-  	feature krb-principal-name-op {
-  		description "Support for Kerberos Principal
-  			Name option";
-  	}
-  	feature client-link-layer-addr-op {
-  		description "Support for Client Link-Layer Address
-  			Option";
-  	}
-  	feature operator-op-ipv6-address {
-  		description "Support for Option with IPv6 Addresses";
-  	}
-  	feature operator-op-single-flag {
-  		description "Support for Option with Single Flag";
-  	}
-  	feature operator-op-ipv6-prefix {
-  		description "Support for Option with IPv6 Prefix";
-  	}
+	feature nis-domain-name-op {
+		description "Support for Network Information Service (NIS)
+			Domain Name option";
+	}
+	feature nis-plus-domain-name-op {
+		description "Support for Network Information Service V2 (NIS+)
+			Server option";
+	}
+	feature sntp-server-op {
+		description "Support for Simple Network Protocol Configuration 
+			(SNTP) Servers option";
+	}
+	feature info-refresh-time-op {
+		description "Support for Information Refresh Time option";
+	}
+	feature client-fqdn-op {
+		description "Support for Client FQDN option";
+	}
+	feature posix-timezone-op {
+		description "Support for New POIX Timezone option";
+	}
+	feature tzdb-timezone-op {
+		description "Support for New TZDB Timezone option";
+	}
+	feature ntp-server-op {
+		description "Support for Network Time Protocol (NTP) 
+			Server option";
+	}
+	feature boot-file-url-op {
+		description "Support for Boot File URL option";
+	}
+	feature boot-file-param-op {
+		description "Support for Boot File Parameters option";
+	}
+	feature aftr-name-op {
+		description "Support for Address Family Transition
+			Router (AFTR) option";
+	}
+	feature kbr-default-name-op {
+		description "Support for Kerberos Default Name 
+			Option";
+	}
+	feature kbr-kdc-op {
+		description "Support for Kerberos KDC option";
+	}
+	feature sol-max-rt-op {
+		description "Support for SOL_MAX_RT option";
+	}
+	feature inf-max-rt-op {
+		description "Support for INF_MAX_RT option";
+	}
+	feature addr-selection-op {
+		description "Support for Address Selection opiton";
+	}
+	feature pcp-server-op {
+		description "Support for Port Control Protocol (PCP)
+			option";
+	}
+	feature s46-rule-op {
+		description "Support for S46 Rule option";
+	}
+	feature s46-br-op {
+		description "Support for S46 Border Relay (BR) option";
+	}
+	feature s46-dmr-op {
+		description "Support for S46 Default Mapping Rule 
+			(DMR) option";
+	}
+	feature s46-v4-v6-binding-op {
+		description "Support for S46 IPv4/IPv6 Address
+			Bind option";
+	}
+	
+	// features for relay-supplied options
+	feature erp-local-domain-name-op {
+		description "Support for ERP Local Domain
+			Name option";
+	}
+	
+	// features for client options
+	feature option-request-op {
+		description "Support for Option Request option";
+	}
+	feature rapid-commit-op {
+		description "Support for Rapid Commit option";
+	}
+	feature user-class-op {
+		description "Support for User Class option";
+	}
+	feature vendor-class-op {
+		description "Support for Vendor Class option";
+	}
+	feature client-arch-type-op {
+		description "Support for Client System Architecture
+			Type option";
+	}
+	feature client-network-interface-identifier-op {
+		description "Support for Client Network Interface
+			Identifier option";
+	}
+	feature kbr-principal-name-op {
+		description "Support for Kerberos Principal
+			Name option";
+	}
+	feature kbr-realm-name-op {
+		description "Support Kerberos Realm Name option";
+	}
+	feature client-link-layer-addr-op {
+		description "Support for Client Link-Layer Address
+			Option";
+	}
+	
+	// features for custom options
+	feature operator-op-ipv6-address {
+		description "Support for Option with IPv6 Addresses";
+	}
+	feature operator-op-single-flag {
+		description "Support for Option with Single Flag";
+	}
+	feature operator-op-ipv6-prefix {
+		description "Support for Option with IPv6 Prefix";
+	}
 	feature operator-op-int32 {
 		description "Support for Opion with 32-bit
 			Integer Value";
@@ -212,52 +240,131 @@ module ietf-dhcpv6-options {
    }
   }
 
+  grouping duid {
+	    description "DHCP Unique Identifier";
+	    reference "RFC3315: Section 9";
+	    leaf type-code {
+        	type uint16;
+        	default 65535;
+        	description "Type code of this DUID";
+        }
+	    choice duid-type {
+		  default duid-invalid;
+	      description "Selects the format for the DUID.";
+	      case duid-llt {
+	        description "DUID Based on Link-layer Address Plus Time (Type 1 - DUID-LLT)";
+	        reference "RFC3315 Section 9.2";
+
+	        leaf duid-llt-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-llt-time {
+	          type yang:timeticks;
+	          description "The time value is the time that the DUID is generated
+	            represented in seconds since midnight (UTC), January 1, 2000,
+	                        modulo 2^32.";
+	        }
+	        leaf duid-llt-link-layer-addr {
+	          type yang:mac-address;
+	          description "Link-layer address as described in RFC2464";
+	        }
+	      }
+	      case duid-en {
+	        description "DUID Assigned by Vendor Based on Enterprise Number (Type 2 - DUID-EN)";
+	        reference "RFC3315 Section 9.3";
+	        leaf duid-en-enterprise-number {
+	          type uint32;
+	          description "Vendor's registered Private Enterprise Number as
+	            maintained by IANA";
+	        }
+	        leaf duid-en-identifier {
+	          type string;
+	          description "Indentifier, unique to the device that is using it";
+	        }
+	      }
+	      case duid-ll {
+	        description "DUID Based on Link-layer Address (Type 3 - DUID-LL)";
+	        reference "RFC3315 Section 9.4";
+	        leaf duid-ll-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-ll-link-layer-addr {
+		          type yang:mac-address;
+		          description "Link-layer address as described in RFC2464";
+		    }
+	      }
+	      case duid-uuid {
+	    	  description "DUID Based on Universally Unique Identifier (Type 4 - DUID-UUID)";
+	    	  reference "RFC6335 Defination of the UUID-Based Unique Identifier";
+	    	  leaf uuid {
+	    		  type yang:uuid;
+	    		  description "A Universally Unique IDentifier in the string representation
+	    		      defined in RFC 4122.  The canonical representation uses
+	    		      lowercase characters";
+	    	  }    	  
+	      }
+	      case duid-invalid {
+	    	  description "DUID based on free raw bytes";
+	    	  leaf data {
+	    		  type binary;
+	    		  description "The bits to be used as the identifier";
+	    	  }
+	      }	      
+	    }
+	  }
+  
   grouping server-option-definitions {
     description "Contains definitions for options configured on the
       DHCPv6 server which will be supplied to clients.";
     container server-unicast-option {
       if-feature server-unicast-op;
+      presence "Enable this option";
       description "OPTION_UNICAST (12) Server Unicast Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
       leaf server-address {
         type inet:ipv6-address;
+        description "server ipv6 address";
       }
     }
-    container sip-server-option {
-      if-feature sip-server-op;
-      presence "Enable this option";
-      description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List
-      and OPTION_SIP_SERVER_A (22) SIP Servers IPv6 Address List";
-      /* if - Note - this container is currently modelling two options
-       (21 & 22). It would allow the config of a mixed list of domain
-       names and addresses in a way that doesn't follow the
-       RFC. Needs to be broken into SIP Domain list and SIP Address
-       list containers */
-      reference "RFC3319: Dynamic Host Configuration Protocol
-        (DHCPv6) Options for Session Initiation Protocol (SIP)
-        Servers";
-      list sip-server {
-        key sip-serv-id;
-        description "sip server info";
-        leaf sip-serv-id {
-          type uint8;
-          mandatory true;
-          description "sip server id";
-        }
-        leaf sip-serv-domain-name {
-          type string;
-          mandatory true;
-          description "sip server domain
-            name";
-        }
-        leaf sip-serv-addr {
-          type inet:ipv6-address;
-          mandatory true;
-          description "sip server addr";
-        }
-      }
+    container sip-server-domain-name-list-option {
+        if-feature sip-server-domain-name-list-op;
+        presence "Enable this option";
+        description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List";
+        reference "RFC3319: Dynamic Host Configuration Protocol
+          (DHCPv6) Options for Session Initiation Protocol (SIP)
+          Servers";
+          leaf sip-serv-domain-name {
+            type string;
+            mandatory true;
+            description "sip server domain
+              name";
+          }
     }
+    container sip-server-address-list-option {
+        if-feature sip-server-address-list-op;
+        presence "Enable this option";
+        description "OPTION_SIP_SERVER_A (22) SIP Servers IPv6 Address List";
+        reference "RFC3319: Dynamic Host Configuration Protocol
+          (DHCPv6) Options for Session Initiation Protocol (SIP)
+          Servers";
+        list sip-server {
+          key sip-serv-id;
+          description "sip server info";
+          leaf sip-serv-id {
+            type uint8;
+            mandatory true;
+            description "sip server id";
+          }
+          leaf sip-serv-addr {
+            type inet:ipv6-address;
+            mandatory true;
+            description "sip server addr";
+          }
+        }
+    }   
     container dns-config-option {
       if-feature dns-config-op;
       presence "Enable this option";
@@ -410,8 +517,8 @@ module ietf-dhcpv6-options {
         description "The refresh time.";
       }
     }
-    container cli-fqdn-option {
-      if-feature cli-fqdn-op;
+    container client-fqdn-option {
+      if-feature client-fqdn-op;
       presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) DHCPv6 Client FQDN Option";
       reference "RFC4704: The Dynamic Host Configuration Protocol for IPv6
@@ -457,6 +564,10 @@ module ietf-dhcpv6-options {
     container ntp-server-option {
       //This option looks like it needs work to correctly model the
       //option as defined in the RFC.
+    	
+      // Zihao - Re-modelled so it only contains one 
+    	// time source suboption
+      
       if-feature ntp-server-op;
       presence "Enable this option";
       description "OPTION_NTP_SERVER (56) NTP Server Option for DHCPv6";
@@ -470,67 +581,79 @@ module ietf-dhcpv6-options {
           mandatory true;
           description "ntp server id";
         }
-        leaf ntp-serv-addr-suboption {
-          type inet:ipv6-address;
-          mandatory true;
-          description "ntp server addr";
-        }
-        leaf ntp-serv-mul-addr-suboption {
-          type inet:ipv6-address;
-          mandatory true;
-          description "ntp server multicast addr";
-        }
-        leaf ntp-serv-fqdn-suboption {
-          type string;
-          mandatory true;
-          description "ntp server fqdn";
-        }
-      }
-    }
-    container network-boot-option {
-      description "OPT_BOOTFILE_URL (59) and OPT_BOOTFILE_PARAM (60)";
-      reference "RFC5970: DHCPv6 Options for Network Boot";
-      // if - Looks like 2 options combined that need to be split out
-      if-feature network-boot-op;
-      presence "Enable this option";
-      list boot-file {
-        key boot-file-id;
-        description "boot file info";
-        leaf boot-file-id {
-          type uint8;
-          mandatory true;
-          description "boot file id";
-        }
-        leaf-list suitable-arch-type {
-          type uint16;
-          description "architecture type";
-        }
-        leaf-list suitable-net-if {
-          type uint32;
-          description "network interface";
-        }
-        leaf boot-file-url {
-          type string;
-          mandatory true;
-          description "url for boot file";
-        }
-        list boot-file-paras {
-          key para-id;
-          description "boot file parameters";
-          leaf para-id {
-            type uint8;
-            mandatory true;
-            description "parameter id";
-          }
-          leaf parameter {
-            type string;
-            mandatory true;
-            description "parameter
-              value";
-          }
+        choice ntp-time-source-suboption {
+        	description "Select a NTP time source suboption.";
+        	case server-address {
+	    	leaf-list ntp-serv-addr-suboption {
+	    	          type inet:ipv6-address;
+	    	          description "ntp server addr";
+	    	        }
+        	}
+        	case server-multicast-address {
+        		leaf-list ntp-serv-mul-addr-suboption {
+        	          type inet:ipv6-address;
+        	          description "ntp server multicast addr";
+        	        }
+        	}
+        	case server-fqdn {
+        		leaf-list ntp-serv-fqdn-suboption {
+                    type string;
+                    description "ntp server fqdn";
+                  }
+        	}       	
         }
       }
-    }
+    }    
+  	container boot-file-url-option {
+  		if-feature boot-file-url-op;
+  		presence "Enable this option";
+  		description "OPT_BOOTFILE_URL (59) Boot File URL option";
+  		reference "RFC5970: DHCPv6 Options for Network Boot";		
+  		list boot-file {
+  			key boot-file-id;
+  			description "boot file info";
+  			leaf boot-file-id {
+  				type uint8;
+  				mandatory true;
+  				description "boot file id";
+  			}
+  	        leaf-list suitable-arch-type {
+  	            type uint16;
+  	            description "architecture type";
+  	          }
+            	leaf-list suitable-net-if {
+              	type uint32;
+              	description "network interface";
+            	}
+  			leaf boot-file-url {
+  				type string;
+  				mandatory true;
+  				description "url for boot file";
+  			}
+  		}
+  	}	
+  	container boot-file-param-option {
+  		if-feature boot-file-param-op;
+  		presence "Enable this option";
+  		description "OPT_BOOTFiLE_PARAM (60) Boot File Parameters Option";
+  		reference "RFC5970: DHCPv6 Options for Network Boot";
+          list boot-file-paras {
+              key para-id;
+              description "boot file parameters";
+              leaf para-id {
+                type uint8;
+                mandatory true;
+                description "parameter id";
+              }
+              leaf parameter {
+                type string;
+                mandatory true;
+                description "parameter
+                  value";
+              }
+              
+            }
+  	}   
     container aftr-name-option {
       if-feature aftr-name-op;
       presence "Enable this option";
@@ -542,61 +665,63 @@ module ietf-dhcpv6-options {
         mandatory true;
         description "aftr name";
       }
+    }    
+    container kbr-default-name-option {
+    	if-feature kbr-default-name-op;
+    	presence "Enable this option";
+    	description "OPTION_KRB_DEFAULT_REALM_NAME (77) Kerberos Default Realm Name Option";
+    	reference "RFC6784: Kerberos Options for DHCPv6";
+        leaf default-realm-name {
+            type string;
+            mandatory true;
+            description "default realm name";
+          }
     }
-    container kerberos-option {
-      //This needs re-working and possibly splitting into several option
-      //containers to follow the RFC.
-      if-feature kerberos-op;
-      presence "Enable this option";
-      description "OPTION_KRB_KDC (78) Kerberos KDB Option, OPTION_KRB_REALM_NAME (76)
-        Kerberos Realm Name Option and OPTION_KRB_DEFAULT_REALM_NAME (77)
-        Kerberos Default Realm Name Option";
-      reference "RFC6784: Kerberos Options for DHCPv6";
-      leaf default-realm-name {
-        type string;
-        mandatory true;
-        description "default realm name";
-      }
-      list kdc-info {
-        key kdc-id;
-        description "kdc info";
-        leaf kdc-id {
-          type uint8;
-          mandatory true;
-          description "kdc id";
-        }
-        leaf priority {
-          type uint16;
-          mandatory true;
-          description "priority";
-        }
-        leaf weight {
-          type uint16;
-          mandatory true;
-          description "weight";
-        }
-        leaf transport-type {
-          type uint8;
-          mandatory true;
-          description "transport type";
-        }
-        leaf port-number {
-          type uint16;
-          mandatory true;
-          description "port number";
-        }
-        leaf kdc-ipv6-addr {
-          type inet:ipv6-address;
-          mandatory true;
-          description "kdc ipv6 addr";
-        }
-        leaf realm-name {
-          type string;
-          mandatory true;
-          description "realm name";
-        }
-      }
-    }
+    container kbr-kdc-option {
+    	if-feature kbr-kdc-op;
+    	presence "Enable this option";
+    	description "OPTION_KRB_KDC (78) Kerberos KDB Option";
+    	reference "RFC6784: Kerberos Options for DHCPv6";
+        list kdc-info {
+            key kdc-id;
+            description "kdc info";
+            leaf kdc-id {
+              type uint8;
+              mandatory true;
+              description "kdc id";
+            }
+            leaf priority {
+              type uint16;
+              mandatory true;
+              description "priority";
+            }
+            leaf weight {
+              type uint16;
+              mandatory true;
+              description "weight";
+            }
+            leaf transport-type {
+              type uint8;
+              mandatory true;
+              description "transport type";
+            }
+            leaf port-number {
+              type uint16;
+              mandatory true;
+              description "port number";
+            }
+            leaf kdc-ipv6-addr {
+              type inet:ipv6-address;
+              mandatory true;
+              description "kdc ipv6 addr";
+            }
+            leaf realm-name {
+              type string;
+              mandatory true;
+              description "realm name";
+            }
+          }
+    }    
     container sol-max-rt-option {
       if-feature sol-max-rt-op;
       presence "Enable this option";
@@ -620,7 +745,7 @@ module ietf-dhcpv6-options {
         mandatory true;
         description "inf max rt value";
       }
-    }
+    }       
     container addr-selection-option {
       if-feature addr-selection-op;
       presence "Enable this option";
@@ -629,12 +754,7 @@ module ietf-dhcpv6-options {
       DHCPv6";
       // if - Needs checking to see if this matches the RFC - there
       // are two options here.
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-                  option set";
-        }
+      // Zihao - I think this matches RFC7078
       leaf a-bit-set {
         type boolean;
         mandatory true;
@@ -832,7 +952,7 @@ module ietf-dhcpv6-options {
 
   grouping relay-supplied-option-definitions {
     // if - The structure here needs to be checked and probably reworked.
-    description "Relay supplied DHCP Options";
+    description "OPTION_RSOO (66) Relay-Supplied Options option";
     reference "RFC6422: Relay-Supplied DHCP Options";
     container erp-local-domain-name-option {
       if-feature erp-local-domain-name-op;
@@ -853,6 +973,7 @@ module ietf-dhcpv6-options {
           description "Sets the DUID";
           // uses duid;
           // if - Maybe DUID definition needs to be moved to this module.
+          uses duid;
         }
         leaf erp-name {
           type string;
@@ -917,18 +1038,7 @@ module ietf-dhcpv6-options {
         }
       }
     }
-    container rapid-commit-option {
-      if-feature rapid-commit-op;
-      description "OPTION_RAPID_COMMIT (14)";
-      reference "RFC3315: Dynamic Host Configuration Protocol
-      for IPv6 (DHCPv6)";
-      leaf enable-rapid-commit {
-        type boolean;
-      }
-      // if - This fuction is also being covered by
-      // /client/client-if/rapid-commit switch. Is it better
-      // defined there or as an option?
-    }
+
     container user-class-option {
       if-feature user-class-op;
       presence "Enable this option";
@@ -963,21 +1073,29 @@ module ietf-dhcpv6-options {
         type uint32;
         mandatory true;
         description "enterprise number";
+      }     
+      list vendor-class {
+    	  key vendor-class-id;
+    	  description "vendor class";
+          leaf vendor-class-id {
+              type uint8;
+              mandatory true;
+              description "vendor class id";
+            }
+          leaf vendor-class-data {
+        	  type string;
+        	  mandatory true;
+        	  description "The vendor-class-data is composed of a series
+                  of separate items, each of which describes some
+                  characteristic of the client's hardware configuration.
+                  Examples of vendor-class-data instances might include the
+                  version of the operating system the client is running or
+                  the amount of memory installed on the client.";
+          }
       }
-      leaf-list vendor-class-data {
-        type string;
-        description "The vendor-class-data is composed of a series
-          of separate items, each of which describes some
-          characteristic of the client's hardware configuration.
-          Examples of vendor-class-data instances might include the
-          version of the operating system the client is running or
-          the amount of memory installed on the client.";
-          // if - It may be better to model this as a leaf-list
-          // so the list contents can be indexed.
-      }
-    }
+    }   
     container client-fqdn-option {
-      if-feature cli-fqdn-op;
+      if-feature client-fqdn-op;
       presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) The Dynamic Host
         Configuration Protocol for IPv6 (DHCPv6) Client Fully
@@ -1025,9 +1143,8 @@ module ietf-dhcpv6-options {
     container client-network-interface-identifier-option {
       if-feature client-network-interface-identifier-op;
       presence "Enable this option";
-      description
-        "OPTION_NII (62) Client Network Interface Identifier
-        Option";
+      description "OPTION_NII (62) Client Network Interface 
+    	  Identifier Option";
       reference "RFC5970: DHCPv6 Options for Network Boot";
       leaf type {
         type uint8;
@@ -1045,18 +1162,43 @@ module ietf-dhcpv6-options {
         description "minor";
       }
     }
-    container krb-principal-name-option {
-      if-feature krb-principal-name-op;
+    container kbr-principal-name-option {
+      if-feature kbr-principal-name-op;
       presence "Enable this option";
       description "OPTION_KRB_PRINCIPAL_NAME (75) Kerberos
         Principal Name Option";
       reference "RFC6784: Kerberos Options for DHCPv6";
-      leaf principal-name {
-        type string;
-        mandatory true;
-        description "principal name";
-        // if - this can probably be typed according to RFC4120 5.2.2
+      list principle-name {
+    	  key principle-name-id;
+    	  description "principle name";
+    	  leaf principle-name-id {
+    		  type uint8;
+    		  mandatory true;
+    		  description "principle name id";
+    	  }
+    	  leaf name-type {
+    		  type int32;
+    		  mandatory true;
+    		  description "This field specifies the type of name that follows.";
+    	  }
+    	  leaf name-string {
+    		  type string;
+    		  mandatory true;
+    		  description "This field encodes a sequence of components that form
+    			  a name, each component encoded as a KerberoString";
+    	  }
       }
+      }   
+    container kbr-realm-name-option {
+    	if-feature kbr-realm-name-op;
+    	presence "Enable this option";
+    	description "OPTION_KRB_REALM_NAME (76) Kerberos Realm Name Option";
+    	reference "RFC6784: Kerberos Options for DHCPv6";
+    	leaf realm-name {
+    		type string;
+    		mandatory true;
+    		description "realm name";
+    	}
     }
     container client-link-layer-addr-option {
       if-feature client-link-layer-addr-op;
@@ -1078,9 +1220,12 @@ module ietf-dhcpv6-options {
         description "Client link-layer address";
       }
     }
-  }
+    }
+
+  
 
   grouping custom-option-definitions {
+	description "operator customized options";
     container operator-option-ipv6-address {
       if-feature operator-op-ipv6-address;
       presence "Enable this option";

--- a/ietf-dhcpv6-relay@2017-11-24.yang
+++ b/ietf-dhcpv6-relay@2017-11-24.yang
@@ -1,4 +1,5 @@
 module ietf-dhcpv6-relay {
+	yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-dhcpv6-relay";
   prefix "dhcpv6-client";
 
@@ -9,23 +10,22 @@ module ietf-dhcpv6-relay {
 
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-11-24";
+    revision-date "2017-12-22";
   }
 
   organization "DHC WG";
   contact "yong@csnet1.cs.tsinghua.edu.cn
-    wangh13@mails.tsinghua.edu.cn
     lh.sunlinh@gmail.com
     ian.farrer@telekom.de
-    sladjana.zechlin@telekom.de";
+    sladjana.zechlin@telekom.de
+    hezihao9512@gmail.com";
 
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 relay.";
 
-  revision 2017-11-29{
-	  description "separation of relay configuration and 
-		  state trees";
-	  reference "I-d: draft-ietf-dhc-dhcpv6-yang";
+  revision 2017-12-22 {
+	  description "Resolve most issues on Ian's github.";
+	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
   
   revision 2017-11-24 {
@@ -60,11 +60,10 @@ module ietf-dhcpv6-relay {
    */
 
 container relay {
+	presence "Enables the relay";
     description "dhcpv6 relay portion";
-    
     container relay-config{
     	description "configuration tree of relay";
-    	
         container relay-attributes {
             description "A container describes
               some basic attributes of the relay
@@ -122,10 +121,25 @@ container relay {
           }
 
           container rsoo-option-sets {
+        	description "DHCPv6 relay agent could provide
+                some information that would be useful to DHCPv6 client. 
+        		Since relay agent cannot provide options directly to 
+        		the client, RSOO-enabled options are defined to 
+        		propose options for the server to send to the client. 
+        		This container models such RSOO-enabled options.";
+        	reference "RFC6422";
             list option-set {
               key id;
+              description "This list under the 'rsoo-option-sets' container 
+              is similar to the that defined in server module. It allows 
+              the relay to implement several sets of RSOO-enabled options 
+              for different interfaces. The list only include the EAP 
+              Re-authentication Protocol (ERP) Local Domain Name DHCPv6 Option 
+              defined in RFC6440, since it is the only one 
+              RSOO-enabled options accepted by IANA so far.";
                 leaf id {
                   type uint32;
+                  description "option sed id";
                 }
               uses dhcpv6-options:relay-supplied-option-definitions;
             }
@@ -167,38 +181,6 @@ container relay {
               }
               description "Configured Relay Supplied Option set";
             }
-            list pd-route {
-              // if - need to look at if/how we model these. If they are
-              // going to be modelled, then they should be ro state
-              // entries (we're not trying to configure routes here)
-              key pd-route-id;
-              description "pd route";
-              leaf pd-route-id {
-                type uint8;
-                mandatory true;
-                description "pd route id";
-              }
-              leaf requesting-router-id {
-                type uint32;
-                mandatory true;
-                description "requesting router id";
-              }
-              leaf delegating-router-id {
-                type uint32;
-                mandatory true;
-                description "delegating router id";
-              }
-              leaf next-router {
-                type inet:ipv6-address;
-                mandatory true;
-                description "next router";
-              }
-              leaf last-router {
-                type inet:ipv6-address;
-                mandatory true;
-                description "previous router";
-              }
-            }
             list next-entity {
               key dest-addr;
               description "This node defines
@@ -237,9 +219,8 @@ container relay {
     
     
 	container relay-state{
-		description "state tree of relay";
-		
 		config "false";
+		description "state tree of relay";
 		list relay-if{
 			key if-name;
 			description "...";			
@@ -248,8 +229,44 @@ container relay {
 				mandatory true;
 				description "interface name";
 			}
+            list pd-route {
+                // if - need to look at if/how we model these. If they are
+                // going to be modelled, then they should be ro state
+                // entries (we're not trying to configure routes here)
+                key pd-route-id;
+                description "pd route";
+                leaf pd-route-id {
+                  type uint8;
+                  mandatory true;
+                  description "pd route id";
+                }
+                leaf requesting-router-id {
+                  type uint32;
+                  mandatory true;
+                  description "requesting router id";
+                }
+                leaf delegating-router-id {
+                  type uint32;
+                  mandatory true;
+                  description "delegating router id";
+                }
+                leaf next-router {
+                  type inet:ipv6-address;
+                  mandatory true;
+                  description "next router";
+                }
+                leaf last-router {
+                  type inet:ipv6-address;
+                  mandatory true;
+                  description "previous router";
+                }
+              }
 			list next-entity{
 				key dest-addr;
+				description "This node defines a list that is used to 
+					describe the next hop entity of this relay agent. 
+					Different entities are distinguished by their 
+					addresses.";
 				leaf dest-addr{
 					type inet:ipv6-address;
 					mandatory true;
@@ -409,6 +426,7 @@ container relay {
    */
 
   notification notifications {
+    description "dhcpv6 relay notification module";
     container dhcpv6-relay-event {
       description "dhcpv6 relay event";
       container topo-changed {

--- a/ietf-dhcpv6-server@2017-11-24.yang
+++ b/ietf-dhcpv6-server@2017-11-24.yang
@@ -1,4 +1,5 @@
 module ietf-dhcpv6-server {
+  yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-dhcpv6-server";
   prefix "dhcpv6-server";
 
@@ -12,29 +13,27 @@ module ietf-dhcpv6-server {
   }
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-11-24";
+    revision-date "2017-12-22";
   }
 
   organization "DHC WG";
   contact "yong@csnet1.cs.tsinghua.edu.cn
-    wangh13@mails.tsinghua.edu.cn
     lh.sunlinh@gmail.com
     ian.farrer@telekom.de
-    sladjana.zechlin@telekom.de";
+    sladjana.zechlin@telekom.de
+    hezihao9512@gmail.com";
 
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 server.";
 
-  revision 2017-11-29 {
-	  description "First version of separation of server configuration
-		  and state trees.";
+  revision 2017-12-22 {
+	  description "Resolve most issues on Ian's github.";
 	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
   
   revision 2017-11-24 {
     description "First version of the separated server specific
       YANG model.";
-
     reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
 
@@ -76,133 +75,172 @@ module ietf-dhcpv6-server {
    }
   }
   
-
   grouping duid {
-    description "DHCP Unique Identifier";
-    reference "RFC3315: Section 9";
-    choice duid-type {
-      description "Selects the format for the DUID.";
-      case duid-llt {
-        description "DUID Based on Link-layer Address Plus Time";
-        reference "RFC3315 Section 9.2";
-        leaf duid-llt-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
-        }
-        leaf duid-llt-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-                        modulo 2^32.";
-        }
-        leaf duid-llt-link-layer-addr {
-          type yang:mac-address;
-          description "Link-layer address as described in RFC2464";
-        }
-      }
-      case duid-en {
-        description "DUID Assigned by Vendor Based on Enterprise Number";
-        reference "RFC3315 Section 9.3";
-        leaf duid-en-enterprise-number {
-          type uint32;
-          description "Vendor's registered Private Enterprise Number as
-            maintained by IANA";
-        }
-        leaf duid-en-identifier {
-          type string;
-          description "Indentifier, unique to the device that is using it";
-        }
-      }
-      case duid-ll {
-        description "DUID Based on Link-layer Address";
-        reference "RFC3315 Section 9.4";
-        leaf duid-ll-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
-        }
-        leaf duid-ll-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-                        modulo 2^32.";
-        }
-      }
-    }
-  }
+	    description "DHCP Unique Identifier";
+	    reference "RFC3315: Section 9 and RFC6355: Section 4";
+	    leaf type-code {
+      	type uint16;
+      	default 65535;
+      	description "Type code of this DUID";
+	    }
+	    choice duid-type {
+		  default duid-invalid;
+	      description "Selects the format for the DUID.";
+	      case duid-llt {
+	        description "DUID Based on Link-layer Address Plus Time (Type 1 - DUID-LLT)";
+	        reference "RFC3315 Section 9.2";
+	        leaf duid-llt-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-llt-time {
+	          type yang:timeticks;
+	          description "The time value is the time that the DUID is generated
+	            represented in seconds since midnight (UTC), January 1, 2000,
+	            modulo 2^32.";
+	        }
+	        leaf duid-llt-link-layer-addr {
+	          type yang:mac-address;
+	          description "Link-layer address as described in RFC2464";
+	        }
+	      }
+	      case duid-en {
+	        description "DUID Assigned by Vendor Based on Enterprise Number (Type 2 - DUID-EN)";
+	        reference "RFC3315 Section 9.3";
+	        leaf duid-en-enterprise-number {
+	          type uint32;
+	          description "Vendor's registered Private Enterprise Number as
+	            maintained by IANA";
+	        }
+	        leaf duid-en-identifier {
+	          type string;
+	          description "Indentifier, unique to the device that is using it";
+	        }
+	      }
+	      case duid-ll {
+	        description "DUID Based on Link-layer Address (Type 3 - DUID-LL)";
+	        reference "RFC3315 Section 9.4";
+	        leaf duid-ll-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-ll-link-layer-addr {
+		          type yang:mac-address;
+		          description "Link-layer address as described in RFC2464";
+		    }
+	      }
+	      case duid-uuid {
+	    	  description "DUID Based on Universally Unique Identifier (Type 4 - DUID-UUID)";
+	    	  reference "RFC6335 Defination of the UUID-Based Unique Identifier";
+	    	  leaf uuid {
+	    		  type yang:uuid;
+	    		  description "A Universally Unique IDentifier in the string representation
+	    		      defined in RFC 4122.  The canonical representation uses
+	    		      lowercase characters";
+	    	  }    	  
+	      }
+	      case duid-invalid {
+	    	  description "DUID based on free raw bytes";
+	    	  leaf data {
+	    		  type binary;
+	    		  description "The bits to be used as the identifier";
+	    	  }
+	      }	      
+	    }
+	  }
 
   /*
    * Data Nodes
    */
 
   container server {
-    description "dhcpv6 server portion";
-    
-    /*configuration data*/
-    container server-config{
+	presence "Enables the server";
+    description "DHCPv6 server portion";
+    /* 
+     * Configuration data
+     */
+    container server-config {
     	description "configuration tree of server";
     	   container serv-attributes {
-    		      description "This container contains basic attributes
-    		        of a DHCPv6 server such as DUID, server name and so
-    		        on. Some optional functions that can be provided by
-    		        the server is also included.";
-    		      leaf name {
-    		        type string;
-    		        description "server's name";
-    		      }
-    		      container duid {
-    		        description "Sets the DUID";
-    		        uses duid;
-    		      }
-    		      leaf-list ipv6-address {
-    		        type inet:ipv6-address;
-    		        description "Server's IPv6 address.";
-    		      }
-    		      leaf description {
-    		        type string;
-    		        description "Description of the server.";
-    		      }
-    		      leaf pd-function {
-    		        type boolean;
-    		        mandatory true;
-    		        description "Whether the server can act as a
-    		          delegating router to perform prefix delegation
-    		          ([RFC3633]).";
-    		      }
-    		      leaf stateless-service {
-    		        type boolean;
-    		        mandatory true;
-    		        description "A boolean value specifies whether
-    		          the server support client-server exchanges
-    		          involving two messages defined in ([RFC3315]).";
-    		      }
-    		      leaf rapid-commit {
-    		        type boolean;
-    		        mandatory true;
-    		        description "A boolean value specifies whether
-    		          the server support client-server exchanges
-    		          involving two messages defined in ([RFC3315]).";
-    		      }
-    		      leaf-list interfaces-config {
-    		        // Note - this should probably be references to
-    		        // entries in the ietf-interfaces model
-    		        type string;
-    		        description "A leaf list to denote which one or
-    		          more interfaces the server should listen on. The
-    		          default value is to listen on all the interfaces.
-    		          This node is also used to set a unicast address
-    		          for the server to listen with a specific interface.
-    		            For example, if people want the server to listen
-    		              on a unicast address with a specific interface, he
-    		              can use the format like 'eth1/2001:db8::1'.";
-    		      }
-    		      uses vendor-infor;
-    		    }
-    	
+  		      description "This container contains basic attributes
+  		        of a DHCPv6 server such as IPv6 address, server name 
+              and so on. Some optional functions that can be provided 
+              by 0the server is also included.";
+  		      leaf name {
+  		        type string;
+  		        description "server's name";
+  		      }
+  		      container duid {
+  		        description "Sets the DUID";
+  		        uses duid;
+  		      }
+  		      leaf-list ipv6-address {
+  		        type inet:ipv6-address;
+  		        description "Server's IPv6 address.";
+  		      }
+  		      leaf description {
+  		        type string;
+  		        description "Description of the server.";
+  		      }
+  		      leaf pd-function {
+  		        type boolean;
+  		        mandatory true;
+  		        description "Whether the server can act as a
+  		          delegating router to perform prefix delegation
+  		          ([RFC3633]).";
+  		      }
+  		      leaf stateless-service {
+  		        type boolean;
+  		        mandatory true;
+  		        description "A boolean value specifies whether
+  		          the server support client-server exchanges
+  		          involving two messages defined in ([RFC3315]).";
+  		      }
+  		      leaf rapid-commit {
+  		        type boolean;
+  		        mandatory true;
+  		        description "A boolean value specifies whether
+  		          the server support client-server exchanges
+  		          involving two messages defined in ([RFC3315]).";
+  		      }
+  		      leaf-list interfaces-config {
+  		        // Note - this should probably be references to
+  		        // entries in the ietf-interfaces model
+  		        type string;
+  		        description "A leaf list to denote which one or
+  		          more interfaces the server should listen on. The
+  		          default value is to listen on all the interfaces.
+  		          This node is also used to set a unicast address
+  		          for the server to listen with a specific interface.
+  		            For example, if people want the server to listen
+  		              on a unicast address with a specific interface, he
+  		              can use the format like 'eth1/2001:db8::1'.";
+  		      }
+  		      uses vendor-infor;
+    		  }
+
     	    container option-sets {
+    	    	description "DHCPv6 employs various options to carry additional
+    	            information and parameters in DHCP messages. This container defines
+    	            all the possible options that need to be configured at the server
+    	            side. ";
     	        list option-set {
-    	          key id;
+      	          key id;
+    	          description "A server may allow different option sets to be
+    	              configured for different conditions (i.e. different networks,
+    	              clients and etc). This 'option-set' list enables various sets of
+    	              options being defined and configured in a single server. Different
+    	              sets are distinguished by the key called 'option-set-id'. All the
+    	              possible options discussed above are defined in the list and each
+    	              option is corresponding to a container. Since all the options in
+    	              the list are optional, each container in this list has a 'presence'
+    	              statement to indicate whether this option (container) will be 
+    	              included in the current option set or not. In addition, each container
+    	              also has a 'if-feature' statement to indicate whether the server 
+    	              supports this option (container).";
     	            leaf id {
     	              type uint32;
+    	              description "option set id";
     	            }
     	          uses dhcpv6-options:server-option-definitions;
     	          uses dhcpv6-options:custom-option-definitions;
@@ -255,11 +293,12 @@ module ietf-dhcpv6-server {
     	          leaf option-set-id {
     	            type leafref {
     	              path "/server/server-config/option-sets/option-set/id";
+    	              
     	            }
     	            description "The ID field of relevant option-set to be
     	              provisioned to clients of this network-range.";
     	          }
-    	        }
+
     	          container reserved-addresses {
     	            description "reserved addresses";
     	            list static-binding {
@@ -286,6 +325,7 @@ module ietf-dhcpv6-server {
     	                addr";
     	            }
     	          }
+
     	          container reserved-prefixes {
     	            description "reserved prefixes";
     	            list static-binding {
@@ -347,15 +387,16 @@ module ietf-dhcpv6-server {
     	              }
     	            }
     	          }
+
     	          container address-pools {
-    	            description "A container describes
+    	            description "A container that describes
     	              the DHCPv6 server's address pools.";
     	            list address-pool {
     	              key pool-id;
     	              description "A DHCPv6 server can
     	                be configured with several address
     	                pools. This list defines such
-    	                address pools which are distinguish
+    	                address pools which are distinguished
     	                by the key called 'pool-name'.";
     	              leaf pool-id {
     	                type uint32;
@@ -398,10 +439,10 @@ module ietf-dhcpv6-server {
     	                mandatory true;
     	                description "valid liftime for IA";
     	              }
-    	              leaf utilization-ratio {
+    	              leaf max-address-utilization-ratio {
     	                type threshold;
     	                mandatory true;
-    	                description "the utilization ratio";
+    	                description "address pool utilization ratio threshold";
     	              }
     	              leaf inherit-option-set {
     	                type boolean;
@@ -420,7 +461,7 @@ module ietf-dhcpv6-server {
     	              }
     	          }    	               	                	            
     	        }
-    	          
+      	          
     	          container prefix-pools {
       	            description "If a server supports prefix
       	              delegation function, this container will
@@ -439,7 +480,6 @@ module ietf-dhcpv6-server {
       	                description "pool id";
       	              }
       	              leaf prefix {
-      	            	  
       	                type inet:ipv6-prefix;
       	                mandatory true;
       	                description "ipv6 prefix";
@@ -470,10 +510,10 @@ module ietf-dhcpv6-server {
       	                mandatory true;
       	                description "valid lifetime for IA";
       	              }
-      	              leaf utilization-ratio {
+      	              leaf max-prefix-utilization-ratio {
       	                type threshold;
       	                mandatory true;
-      	                description "utilization ratio";
+      	                description "prefix pool utilization ratio threshold";
       	              }
       	              leaf inherit-option-set {
       	                type boolean;
@@ -528,6 +568,8 @@ module ietf-dhcpv6-server {
       	              }
       	            }
       	          }
+    	        }
+
     	      }
     	      container relay-opaque-paras {
     	        description "This container contains some
@@ -535,7 +577,7 @@ module ietf-dhcpv6-server {
     	          need to be configured on the server side
     	          only for value match. Such Relay Agent
     	          options include Interface-Id option,
-    	                  Remote-Id option and Subscriber-Id option.";
+    	          Remote-Id option and Subscriber-Id option.";
     	        list relays {
     	          key relay-name;
     	          description "relay agents";
@@ -608,117 +650,140 @@ module ietf-dhcpv6-server {
     	
     }
       
-    /*State data*/
+    /*
+     * State data
+     */
     container server-state{
     	config "false";
-    	description "states of server";
-    	 	
-    	container network-ranges{   		
+    	description "states of server";    	 	
+    	container network-ranges{ 
+    		description "This model supports a hierarchy
+  	          to achieve dynamic configuration. That is to
+  	          say we could configure the server at different
+  	          levels through this model. The top level is a
+  	          global level which is defined as the container
+  	          'network-ranges'. The following levels are
+  	          defined as sub-containers under it. The
+  	          'network-ranges' contains the parameters
+  	          (e.g. option-sets) that would be allocated to
+  	          all the clients served by this server.";
     		list network-range{
     			key network-range-id;
+          description "The ID field of relevant option-set to be
+                  provisioned to clients of this network-range."; 
     			leaf network-range-id {
-    	            type uint32;
-    	            mandatory true;
-    	            description "equivalent to subnet id";
-    	          }
-  	            description "The ID field of relevant option-set to be
-  	              provisioned to clients of this network-range.";
-  	          
-    			
-    			
-        		container address-pools{
-        			description "A container that describes
-        				the DHCPv6 server's address pools";   			
-            		list address-pool{
-            			key pool-id;
-    	              	leaf pool-id {
-        	                type uint32;
-        	                mandatory true;
-        	                description "pool id";
-        	              }
-            			description "...";
-            			leaf total-ipv6-count{
-            				type uint64;
-            				mandatory true;
-            				description "how many ipv6 addresses
-            					are in the pool";
-            			}
-            			leaf used-ipv6-count{
-            				type uint64;
-            				mandatory true;
-            				description "how many are allocated";
-            			}
-            			leaf utilization-ratio{
-            				type threshold;
-            				mandatory true;
-            				description "the utilization ratio";
-            			}
-            		}
-            		list binding-info {
-            			key cli-id;
-            			description "A list that records a binding
-            				information for each DHCPv6 client 
-            				that has already been allocated 
-            				IPv6 addresses.";
-            			leaf cli-id{
-            				type uint32;
-            				mandatory true;
-            				description "client id";
-            				
-            			}
-            			container duid {
-            				description "Read the DUID";
-            				uses duid;
-            			}
-            			list cli-ia{
-            				key iaid;
-            				description "client IA";
-            				leaf ia-type{
-            					type string;
-            					mandatory true;
-            					description "IA type";
-            				}
-            				leaf iaid{
-            					type uint32;
-            					mandatory true;
-            					description "IAID";
-            				}
-            				leaf-list cli-addr{
-            					type inet:ipv6-address;
-            					description "client addr";
-            				}
-            				leaf pool-id{
-            					type uint32;
-            					mandatory true;
-            					description "pool id";
-            				}
-            			}
-            		}
+    	      type uint32;
+            mandatory true;
+            description "equivalent to subnet id";
+          }
+      		container address-pools{
+      			description "A container that describes
+      				the DHCPv6 server's address pools";   			
+          		list address-pool{
+          			key pool-id;
+  	              	leaf pool-id {
+      	                type uint32;
+      	                mandatory true;
+      	                description "pool id";
+      	              }
+          			description "...";
+          			leaf total-ipv6-count {
+          				type uint64;
+          				mandatory true;
+          				description "how many ipv6 addresses
+          					are in the pool";
+          			}
+          			leaf used-ipv6-count {
+          				type uint64;
+          				mandatory true;
+          				description "how many are allocated";
+          			}
+          			leaf address-utilization-ratio {
+          				type uint16;
+          				mandatory true;
+          				description "current address pool utilization ratio";
+          			}
+          		}
+          		list binding-info {
+          			key cli-id;
+          			description "A list that records a binding
+          				information for each DHCPv6 client 
+          				that has already been allocated 
+          				IPv6 addresses.";
+          			leaf cli-id {
+          				type uint32;
+          				mandatory true;
+          				description "client id";
+                  }
+          			container duid {
+          				description "Read the DUID";
+          				uses duid;
+                  }
+          			list cli-ia{
+          				key iaid;
+          				description "client IA";
+          				leaf ia-type {
+          					type string;
+          					mandatory true;
+          					description "IA type";
+          				}
+          				leaf iaid {
+          					type uint32;
+          					mandatory true;
+          					description "IAID";
+          				}
+          				leaf-list cli-addr {
+          					type inet:ipv6-address;
+          					description "client addr";
+          				}
+          				leaf pool-id {
+          					type uint32;
+          					mandatory true;
+          					description "pool id";
+          				}
+          			}
+          		}
         		}    		
         		container prefix-pools{
         			description "If a server supports prefix
         				delegation function, this container will
         				be used to define the delegating router's 
         				prefix pools.";
-        			list binding-info{
+        			list prefix-pool {
+                key pool-id;
+                description "Similar to server's address pools, 
+                  a delegating router can also be configured with 
+                  multiple prefix pools specified by a list
+        	        called 'prefix-pool'.";
+                leaf pool-id {
+                  type uint32;  
+              	  mandatory true;
+                  description "pool id";
+                  }
+          			leaf prefix-utilization-ratio {
+                  type uint16;
+        				  mandatory true;
+        				  description "current prefix pool utilization ratio";
+                  }
+        			}
+        			list binding-info {
         				key cli-id;
-        				description "A list records a binding
-        					information for each DHCPv6 client
-        					that has already been alloated IPv6
-        					addresses.";
-        				leaf cli-id{
-        					type uint32;
+        				description "A list records a binding information 
+                for each DHCPv6 client that has already been 
+                alloated IPv6 addresses.";
+        				leaf cli-id {
+        					type uint32;   
         					mandatory true;
         					description "client id";
         				}
-        				container duid{
+        				container duid {
         					description "Reads the DUID";
         					uses duid;
         				}
-        				list cli-iapd{
+        				list cli-iapd {
         					key iaid;
         					description "client IAPD";
-        					leaf iaid{
+        					leaf iaid {
         						type uint32;
         						mandatory true;
         						description "IAID";
@@ -727,11 +792,11 @@ module ietf-dhcpv6-server {
         						type inet:ipv6-prefix;
         						description "client ipv6 prefix";
         					}    					
-        					leaf-list cli-prefix-len{
+        					leaf-list cli-prefix-len {
         						type uint8;
         						description "client prefix length";
         					}    					
-        					leaf pool-id{
+        					leaf pool-id {
         						type uint32;
         						mandatory true;
         						description "pool id";
@@ -739,12 +804,67 @@ module ietf-dhcpv6-server {
         					
         				}
         			}
-        		}    
+        		}
+        		
+        		list address-prefix-assign-param {
+        			// Zihao - This probably needs further updated.
+        			// But is it a way to represent the address/prefix assignment
+        			// logic?
+        			key cli-id; 
+        			description "This list includes some parameters/identifiers
+        				that the server obtains from DHCPv6 options in this network-range.
+        				These identifiers may be helpful for the server to assign
+        				addresses/prefixes.";
+        			reference "Section 3.12 of RFC7824";       			        			        			        			        			        			
+        			leaf cli-id {
+    					  type uint32;   
+    					  mandatory true;
+    					  description "client id";
+    				  }
+        			leaf source-ipv6-addr {
+        				type inet:ipv6-address;
+        				description "The adrress of the link to which the client 
+        					is attached.";
+        			}
+    	        container duid {
+    	            description "The DUID supplied by the client.";
+    	            uses duid;
+    	        }
+    	        leaf-list iaid {
+    	        	type uint32;
+    	        	description "IAID";
+    	        }
+    	        leaf-list preferred-addr {
+    	        	type inet:ipv6-address;
+    	        	description "The IPv6 address preferred by the client.";
+    	        }
+    	        leaf-list preferred-prefix-len {
+    	        	type uint8;
+    	        	description "The prefix length preferred by the client.";
+    	        }
+    	        leaf client-fqdn {
+    	        	type string;
+    	        	description "Fully Qualified Domain Name supplied by the client.";
+    	        }
+        			leaf client-link-layer-addr {
+        				type uint16;
+        				description "Link-layer address supplied by the client.";
+        			}
+        			leaf client-enterprise-number {
+        				type uint32;
+        				description "Enterprise number supplied by the client.";
+        			}
+    					leaf-list client-sys-archi-type {
+    						type uint16;
+    						description "Supported system architecture type supplied by 
+    							the client";
+    					}   					            			
+        		}
+          	       
+          	      }
+        		        		        		
     		}
-    		}
-		    		
-    	
-    	
+   		    	
         container packet-stats {
               description "A container presents
               the packet statistics related to
@@ -825,7 +945,7 @@ module ietf-dhcpv6-server {
    */
 
   notification notifications {
-    description "dhcpv6 notification module";
+    description "dhcpv6 server notification module";
     container dhcpv6-server-event {
       description "dhcpv6 server event";
       container pool-running-out {
@@ -834,38 +954,53 @@ module ietf-dhcpv6-server {
           been defined in the server feature so that it will notify the
           administrator when the utilization ratio reaches the
           threshold, and such threshold is a settable parameter";
-        leaf utilization-ratio {
-          type uint16;
-          mandatory true;
-          description "utilization ratio";
-        }
-        container duid {
-          description "Sets the DUID";
-          uses duid;
-        }
-        leaf serv-name {
-          type string;
-          description "server name";
-        }
-        leaf pool-name {
-          type string;
-          mandatory true;
-          description "pool name";
-        }
+      leaf max-address-utilization-ratio {
+        type uint16;
+        mandatory true;
+        description "address pool utilization ratio threshold";
       }
-      container invalid-client-detected {
-        description "raised when the server has found a client which
-          can be regarded as a potential attacker. Some description
-          could also be included.";
-        container duid {
-          description "Sets the DUID";
-          uses duid;
-        }
-        leaf description {
-          type string;
-          description "description of the event";
-        }
+  		leaf address-utilization-ratio {
+  			type uint16;
+  			mandatory true;
+  			description "current address pool utilization ratio";
+  		}
+  		leaf max-prefix-utilization-ratio {
+  	          type uint16;
+  	          mandatory true;
+  	          description "prefix pool utilization ratio threshold";
+  	        }
+  		leaf prefix-utilization-ratio {
+  			type uint16;
+  			mandatory true;
+  			description "current prefix pool utilization ratio";
+  		}
+      container duid {
+        description "Sets the DUID";
+        uses duid;
+      }
+      leaf serv-name {
+        type string;
+        description "server name";
+      }
+      leaf pool-name {
+        type string;
+        mandatory true;
+        description "pool name";
       }
     }
+    container invalid-client-detected {
+      description "raised when the server has found a client which
+        can be regarded as a potential attacker. Some description
+        could also be included.";
+      container duid {
+        description "Sets the DUID";
+        uses duid;
+      }
+      leaf description {
+        type string;
+        description "description of the event";
+      }
+    }
+  }
   }
 }

--- a/tree-client
+++ b/tree-client
@@ -1,0 +1,282 @@
+module: ietf-dhcpv6-client
+    +--rw client!
+       +--rw client-config
+       |  +--rw duid
+       |  |  +--rw type-code?                   uint16
+       |  |  +--rw (duid-type)?
+       |  |     +--:(duid-llt)
+       |  |     |  +--rw duid-llt-hardware-type?      uint16
+       |  |     |  +--rw duid-llt-time?               yang:timeticks
+       |  |     |  +--rw duid-llt-link-layer-addr?    yang:mac-address
+       |  |     +--:(duid-en)
+       |  |     |  +--rw duid-en-enterprise-number?   uint32
+       |  |     |  +--rw duid-en-identifier?          string
+       |  |     +--:(duid-ll)
+       |  |     |  +--rw duid-ll-hardware-type?       uint16
+       |  |     |  +--rw duid-ll-link-layer-addr?     yang:mac-address
+       |  |     +--:(duid-uuid)
+       |  |     |  +--rw uuid?                        yang:uuid
+       |  |     +--:(duid-invalid)
+       |  |        +--rw data?                        binary
+       |  +--rw client-if* [if-name]
+       |     +--rw if-name                      string
+       |     +--rw cli-id                       uint32
+       |     +--rw description?                 string
+       |     +--rw pd-function                  boolean
+       |     +--rw rapid-commit                 boolean
+       |     +--rw mo-tab
+       |     |  +--rw m-tab    boolean
+       |     |  +--rw o-tab    boolean
+       |     +--rw client-configured-options
+       |        +--rw new-or-standard-cli-option* [option-code]
+       |        |  +--rw option-code           uint16
+       |        |  +--rw option-name           string
+       |        |  +--rw option-description    string
+       |        |  +--rw option-reference?     string
+       |        |  +--rw option-value          string
+       |        +--rw option-request-option! {option-request-op}?
+       |        |  +--rw oro-option* [option-code]
+       |        |     +--rw option-code    uint16
+       |        |     +--rw description    string
+       |        +--rw user-class-option! {user-class-op}?
+       |        |  +--rw user-class* [user-class-id]
+       |        |     +--rw user-class-id      uint8
+       |        |     +--rw user-class-data    string
+       |        +--rw vendor-class-option! {vendor-class-op}?
+       |        |  +--rw enterprise-number    uint32
+       |        |  +--rw vendor-class* [vendor-class-id]
+       |        |     +--rw vendor-class-id      uint8
+       |        |     +--rw vendor-class-data    string
+       |        +--rw client-fqdn-option! {client-fqdn-op}?
+       |        |  +--rw fqdn                      string
+       |        |  +--rw server-initiate-update    boolean
+       |        |  +--rw client-initiate-update    boolean
+       |        +--rw client-arch-type-option! {client-arch-type-op}?
+       |        |  +--rw architecture-types* [type-id]
+       |        |     +--rw type-id           uint16
+       |        |     +--rw most-preferred    boolean
+       |        +--rw client-network-interface-identifier-option! {client-network-interface-identifier-op}?
+       |        |  +--rw type     uint8
+       |        |  +--rw major    uint8
+       |        |  +--rw minor    uint8
+       |        +--rw kbr-principal-name-option! {kbr-principal-name-op}?
+       |        |  +--rw principle-name* [principle-name-id]
+       |        |     +--rw principle-name-id    uint8
+       |        |     +--rw name-type            int32
+       |        |     +--rw name-string          string
+       |        +--rw kbr-realm-name-option! {kbr-realm-name-op}?
+       |        |  +--rw realm-name    string
+       |        +--rw client-link-layer-addr-option! {client-link-layer-addr-op}?
+       |           +--rw link-layer-type    uint16
+       |           +--rw link-layer-addr    string
+       +--ro client-state
+          +--ro if-other-paras
+             +--ro server-unicast-option! {server-unicast-op}?
+             |  +--ro server-address?   inet:ipv6-address
+             +--ro sip-server-domain-name-list-option! {sip-server-domain-name-list-op}?
+             |  +--ro sip-serv-domain-name    string
+             +--ro sip-server-address-list-option! {sip-server-address-list-op}?
+             |  +--ro sip-server* [sip-serv-id]
+             |     +--ro sip-serv-id      uint8
+             |     +--ro sip-serv-addr    inet:ipv6-address
+             +--ro dns-config-option! {dns-config-op}?
+             |  +--ro dns-server* [dns-serv-id]
+             |     +--ro dns-serv-id      uint8
+             |     +--ro dns-serv-addr    inet:ipv6-address
+             +--ro domain-searchlist-option! {domain-searchlist-op}?
+             |  +--ro domain-searchlist* [domain-searchlist-id]
+             |     +--ro domain-searchlist-id        uint8
+             |     +--ro domain-search-list-entry    string
+             +--ro nis-config-option! {nis-config-op}?
+             |  +--ro nis-server* [nis-serv-id]
+             |     +--ro nis-serv-id      uint8
+             |     +--ro nis-serv-addr    inet:ipv6-address
+             +--ro nis-plus-config-option! {nis-plus-config-op}?
+             |  +--ro nis-plus-server* [nis-plus-serv-id]
+             |     +--ro nis-plus-serv-id      uint8
+             |     +--ro nis-plus-serv-addr    inet:ipv6-address
+             +--ro nis-domain-name-option! {nis-domain-name-op}?
+             |  +--ro nis-domain-name?   string
+             +--ro nis-plus-domain-name-option! {nis-plus-domain-name-op}?
+             |  +--ro nis-plus-domain-name?   string
+             +--ro sntp-server-option! {sntp-server-op}?
+             |  +--ro sntp-server* [sntp-serv-id]
+             |     +--ro sntp-serv-id      uint8
+             |     +--ro sntp-serv-addr    inet:ipv6-address
+             +--ro info-refresh-time-option! {info-refresh-time-op}?
+             |  +--ro info-refresh-time    yang:timeticks
+             +--ro client-fqdn-option! {client-fqdn-op}?
+             |  +--ro server-initiate-update    boolean
+             |  +--ro client-initiate-update    boolean
+             |  +--ro modify-name-from-cli      boolean
+             +--ro posix-timezone-option! {posix-timezone-op}?
+             |  +--ro tz-posix    string
+             +--ro tzdb-timezone-option! {tzdb-timezone-op}?
+             |  +--ro tz-database    string
+             +--ro ntp-server-option! {ntp-server-op}?
+             |  +--ro ntp-server* [ntp-serv-id]
+             |     +--ro ntp-serv-id                    uint8
+             |     +--ro (ntp-time-source-suboption)?
+             |        +--:(server-address)
+             |        |  +--ro ntp-serv-addr-suboption*       inet:ipv6-address
+             |        +--:(server-multicast-address)
+             |        |  +--ro ntp-serv-mul-addr-suboption*   inet:ipv6-address
+             |        +--:(server-fqdn)
+             |           +--ro ntp-serv-fqdn-suboption*       string
+             +--ro boot-file-url-option! {boot-file-url-op}?
+             |  +--ro boot-file* [boot-file-id]
+             |     +--ro boot-file-id          uint8
+             |     +--ro suitable-arch-type*   uint16
+             |     +--ro suitable-net-if*      uint32
+             |     +--ro boot-file-url         string
+             +--ro boot-file-param-option! {boot-file-param-op}?
+             |  +--ro boot-file-paras* [para-id]
+             |     +--ro para-id      uint8
+             |     +--ro parameter    string
+             +--ro aftr-name-option! {aftr-name-op}?
+             |  +--ro tunnel-endpoint-name    string
+             +--ro kbr-default-name-option! {kbr-default-name-op}?
+             |  +--ro default-realm-name    string
+             +--ro kbr-kdc-option! {kbr-kdc-op}?
+             |  +--ro kdc-info* [kdc-id]
+             |     +--ro kdc-id            uint8
+             |     +--ro priority          uint16
+             |     +--ro weight            uint16
+             |     +--ro transport-type    uint8
+             |     +--ro port-number       uint16
+             |     +--ro kdc-ipv6-addr     inet:ipv6-address
+             |     +--ro realm-name        string
+             +--ro sol-max-rt-option! {sol-max-rt-op}?
+             |  +--ro sol-max-rt-value    yang:timeticks
+             +--ro inf-max-rt-option! {inf-max-rt-op}?
+             |  +--ro inf-max-rt-value    yang:timeticks
+             +--ro addr-selection-option! {addr-selection-op}?
+             |  +--ro a-bit-set       boolean
+             |  +--ro p-bit-set       boolean
+             |  +--ro policy-table* [policy-id]
+             |     +--ro policy-id     uint8
+             |     +--ro label         uint8
+             |     +--ro precedence    uint8
+             |     +--ro prefix-len    uint8
+             |     +--ro prefix        inet:ipv6-prefix
+             +--ro pcp-server-option! {pcp-server-op}?
+             |  +--ro pcp-server* [pcp-serv-id]
+             |     +--ro pcp-serv-id      uint8
+             |     +--ro pcp-serv-addr    inet:ipv6-address
+             +--ro s46-rule-option! {s46-rule-op}?
+             |  +--ro s46-rule* [rule-id]
+             |     +--ro rule-id           uint8
+             |     +--ro rule-type         enumeration
+             |     +--ro prefix4-len       uint8
+             |     +--ro ipv4-prefix       inet:ipv4-prefix
+             |     +--ro prefix6-len       uint8
+             |     +--ro ipv6-prefix       inet:ipv6-prefix
+             |     +--ro port-parameter
+             |        +--ro offset      uint8
+             |        +--ro psid-len    uint8
+             |        +--ro psid        uint16
+             +--ro s46-br-option! {s46-br-op}?
+             |  +--ro br* [br-id]
+             |     +--ro br-id           uint8
+             |     +--ro br-ipv6-addr    inet:ipv6-address
+             +--ro s46-dmr-option! {s46-dmr-op}?
+             |  +--ro dmr* [dmr-id]
+             |     +--ro dmr-id             uint8
+             |     +--ro dmr-prefix-len     uint8
+             |     +--ro dmr-ipv6-prefix    inet:ipv6-prefix
+             +--ro s46-v4-v6-binding-option! {s46-v4-v6-binding-op}?
+                +--ro ce* [ce-id]
+                   +--ro ce-id               uint8
+                   +--ro ipv4-addr           inet:ipv4-address
+                   +--ro bind-prefix6-len    uint8
+                   +--ro bind-ipv6-prefix    inet:ipv6-prefix
+                   +--ro port-parameter
+                      +--ro offset      uint8
+                      +--ro psid-len    uint8
+                      +--ro psid        uint16
+
+  notifications:
+    +---n notifications
+       +--ro dhcpv6-client-event
+          +--ro ia-lease-event
+          |  +--ro event-type     enumeration
+          |  +--ro duid
+          |  |  +--ro type-code?                   uint16
+          |  |  +--ro (duid-type)?
+          |  |     +--:(duid-llt)
+          |  |     |  +--ro duid-llt-hardware-type?      uint16
+          |  |     |  +--ro duid-llt-time?               yang:timeticks
+          |  |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+          |  |     +--:(duid-en)
+          |  |     |  +--ro duid-en-enterprise-number?   uint32
+          |  |     |  +--ro duid-en-identifier?          string
+          |  |     +--:(duid-ll)
+          |  |     |  +--ro duid-ll-hardware-type?       uint16
+          |  |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+          |  |     +--:(duid-uuid)
+          |  |     |  +--ro uuid?                        yang:uuid
+          |  |     +--:(duid-invalid)
+          |  |        +--ro data?                        binary
+          |  +--ro iaid           uint32
+          |  +--ro serv-name?     string
+          |  +--ro description?   string
+          +--ro invalid-ia-detected
+          |  +--ro duid
+          |  |  +--ro type-code?                   uint16
+          |  |  +--ro (duid-type)?
+          |  |     +--:(duid-llt)
+          |  |     |  +--ro duid-llt-hardware-type?      uint16
+          |  |     |  +--ro duid-llt-time?               yang:timeticks
+          |  |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+          |  |     +--:(duid-en)
+          |  |     |  +--ro duid-en-enterprise-number?   uint32
+          |  |     |  +--ro duid-en-identifier?          string
+          |  |     +--:(duid-ll)
+          |  |     |  +--ro duid-ll-hardware-type?       uint16
+          |  |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+          |  |     +--:(duid-uuid)
+          |  |     |  +--ro uuid?                        yang:uuid
+          |  |     +--:(duid-invalid)
+          |  |        +--ro data?                        binary
+          |  +--ro cli-duid       uint32
+          |  +--ro iaid           uint32
+          |  +--ro serv-name?     string
+          |  +--ro description?   string
+          +--ro retransmission-failed
+          |  +--ro duid
+          |  |  +--ro type-code?                   uint16
+          |  |  +--ro (duid-type)?
+          |  |     +--:(duid-llt)
+          |  |     |  +--ro duid-llt-hardware-type?      uint16
+          |  |     |  +--ro duid-llt-time?               yang:timeticks
+          |  |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+          |  |     +--:(duid-en)
+          |  |     |  +--ro duid-en-enterprise-number?   uint32
+          |  |     |  +--ro duid-en-identifier?          string
+          |  |     +--:(duid-ll)
+          |  |     |  +--ro duid-ll-hardware-type?       uint16
+          |  |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+          |  |     +--:(duid-uuid)
+          |  |     |  +--ro uuid?                        yang:uuid
+          |  |     +--:(duid-invalid)
+          |  |        +--ro data?                        binary
+          |  +--ro description    enumeration
+          +--ro failed-status-turn-up
+             +--ro duid
+             |  +--ro type-code?                   uint16
+             |  +--ro (duid-type)?
+             |     +--:(duid-llt)
+             |     |  +--ro duid-llt-hardware-type?      uint16
+             |     |  +--ro duid-llt-time?               yang:timeticks
+             |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+             |     +--:(duid-en)
+             |     |  +--ro duid-en-enterprise-number?   uint32
+             |     |  +--ro duid-en-identifier?          string
+             |     +--:(duid-ll)
+             |     |  +--ro duid-ll-hardware-type?       uint16
+             |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+             |     +--:(duid-uuid)
+             |     |  +--ro uuid?                        yang:uuid
+             |     +--:(duid-invalid)
+             |        +--ro data?                        binary
+             +--ro status-code    enumeration

--- a/tree-relay
+++ b/tree-relay
@@ -1,0 +1,95 @@
+module: ietf-dhcpv6-relay
+    +--rw relay!
+       +--rw relay-config
+       |  +--rw relay-attributes
+       |  |  +--rw name?          string
+       |  |  +--rw description?   string
+       |  |  +--rw dest-addrs*    inet:ipv6-address
+       |  |  +--rw subscribers* [subscriber]
+       |  |  |  +--rw subscriber       uint8
+       |  |  |  +--rw subscriber-id    string
+       |  |  +--rw remote-host* [ent-num]
+       |  |  |  +--rw ent-num      uint32
+       |  |  |  +--rw remote-id    string
+       |  |  +--rw vendor-info
+       |  |     +--rw ent-num    uint32
+       |  |     +--rw data*      string
+       |  +--rw rsoo-option-sets
+       |  |  +--rw option-set* [id]
+       |  |     +--rw id                              uint32
+       |  |     +--rw erp-local-domain-name-option! {erp-local-domain-name-op}?
+       |  |        +--rw erp-for-client* [cli-id]
+       |  |           +--rw cli-id      uint32
+       |  |           +--rw duid
+       |  |           |  +--rw type-code?                   uint16
+       |  |           |  +--rw (duid-type)?
+       |  |           |     +--:(duid-llt)
+       |  |           |     |  +--rw duid-llt-hardware-type?      uint16
+       |  |           |     |  +--rw duid-llt-time?               yang:timeticks
+       |  |           |     |  +--rw duid-llt-link-layer-addr?    yang:mac-address
+       |  |           |     +--:(duid-en)
+       |  |           |     |  +--rw duid-en-enterprise-number?   uint32
+       |  |           |     |  +--rw duid-en-identifier?          string
+       |  |           |     +--:(duid-ll)
+       |  |           |     |  +--rw duid-ll-hardware-type?       uint16
+       |  |           |     |  +--rw duid-ll-link-layer-addr?     yang:mac-address
+       |  |           |     +--:(duid-uuid)
+       |  |           |     |  +--rw uuid?                        yang:uuid
+       |  |           |     +--:(duid-invalid)
+       |  |           |        +--rw data?                        binary
+       |  |           +--rw erp-name    string
+       |  +--rw relay-if* [if-name]
+       |     +--rw if-name               string
+       |     +--rw enable                boolean
+       |     +--rw ipv6-address?         inet:ipv6-address
+       |     +--rw interface-id?         string
+       |     +--rw rsoo-option-set-id?   -> /relay/relay-config/rsoo-option-sets/option-set/id
+       |     +--rw next-entity* [dest-addr]
+       |        +--rw dest-addr    inet:ipv6-address
+       |        +--rw available    boolean
+       |        +--rw multicast    boolean
+       |        +--rw server       boolean
+       +--ro relay-state
+          +--ro relay-if* [if-name]
+          |  +--ro if-name        string
+          |  +--ro pd-route* [pd-route-id]
+          |  |  +--ro pd-route-id             uint8
+          |  |  +--ro requesting-router-id    uint32
+          |  |  +--ro delegating-router-id    uint32
+          |  |  +--ro next-router             inet:ipv6-address
+          |  |  +--ro last-router             inet:ipv6-address
+          |  +--ro next-entity* [dest-addr]
+          |     +--ro dest-addr       inet:ipv6-address
+          |     +--ro packet-stats
+          |        +--ro solicit-rvd-count       uint32
+          |        +--ro request-rvd-count       uint32
+          |        +--ro renew-rvd-count         uint32
+          |        +--ro rebind-rvd-count        uint32
+          |        +--ro decline-rvd-count       uint32
+          |        +--ro release-rvd-count       uint32
+          |        +--ro info-req-rvd-count      uint32
+          |        +--ro relay-for-rvd-count     uint32
+          |        +--ro relay-rep-rvd-count     uint32
+          |        +--ro packet-to-cli-count     uint32
+          |        +--ro adver-sent-count        uint32
+          |        +--ro confirm-sent-count      uint32
+          |        +--ro reply-sent-count        uint32
+          |        +--ro reconfig-sent-count     uint32
+          |        +--ro relay-for-sent-count    uint32
+          |        +--ro relay-rep-sent-count    uint32
+          +--ro relay-stats
+             +--ro cli-packet-rvd-count      uint32
+             +--ro relay-for-rvd-count       uint32
+             +--ro relay-rep-rvd-count       uint32
+             +--ro packet-to-cli-count       uint32
+             +--ro relay-for-sent-count      uint32
+             +--ro relay-rep-sent-count      uint32
+             +--ro discarded-packet-count    uint32
+
+  notifications:
+    +---n notifications
+       +--ro dhcpv6-relay-event
+          +--ro topo-changed
+             +--ro relay-if-name       string
+             +--ro first-hop           boolean
+             +--ro last-entity-addr    inet:ipv6-address

--- a/tree-server
+++ b/tree-server
@@ -1,0 +1,470 @@
+module: ietf-dhcpv6-server
+    +--rw server!
+       +--rw server-config
+       |  +--rw serv-attributes
+       |  |  +--rw name?                string
+       |  |  +--rw duid
+       |  |  |  +--rw type-code?                   uint16
+       |  |  |  +--rw (duid-type)?
+       |  |  |     +--:(duid-llt)
+       |  |  |     |  +--rw duid-llt-hardware-type?      uint16
+       |  |  |     |  +--rw duid-llt-time?               yang:timeticks
+       |  |  |     |  +--rw duid-llt-link-layer-addr?    yang:mac-address
+       |  |  |     +--:(duid-en)
+       |  |  |     |  +--rw duid-en-enterprise-number?   uint32
+       |  |  |     |  +--rw duid-en-identifier?          string
+       |  |  |     +--:(duid-ll)
+       |  |  |     |  +--rw duid-ll-hardware-type?       uint16
+       |  |  |     |  +--rw duid-ll-link-layer-addr?     yang:mac-address
+       |  |  |     +--:(duid-uuid)
+       |  |  |     |  +--rw uuid?                        yang:uuid
+       |  |  |     +--:(duid-invalid)
+       |  |  |        +--rw data?                        binary
+       |  |  +--rw ipv6-address*        inet:ipv6-address
+       |  |  +--rw description?         string
+       |  |  +--rw pd-function          boolean
+       |  |  +--rw stateless-service    boolean
+       |  |  +--rw rapid-commit         boolean
+       |  |  +--rw interfaces-config*   string
+       |  |  +--rw vendor-info
+       |  |     +--rw ent-num    uint32
+       |  |     +--rw data*      string
+       |  +--rw option-sets
+       |  |  +--rw option-set* [id]
+       |  |     +--rw id                                    uint32
+       |  |     +--rw server-unicast-option! {server-unicast-op}?
+       |  |     |  +--rw server-address?   inet:ipv6-address
+       |  |     +--rw sip-server-domain-name-list-option! {sip-server-domain-name-list-op}?
+       |  |     |  +--rw sip-serv-domain-name    string
+       |  |     +--rw sip-server-address-list-option! {sip-server-address-list-op}?
+       |  |     |  +--rw sip-server* [sip-serv-id]
+       |  |     |     +--rw sip-serv-id      uint8
+       |  |     |     +--rw sip-serv-addr    inet:ipv6-address
+       |  |     +--rw dns-config-option! {dns-config-op}?
+       |  |     |  +--rw dns-server* [dns-serv-id]
+       |  |     |     +--rw dns-serv-id      uint8
+       |  |     |     +--rw dns-serv-addr    inet:ipv6-address
+       |  |     +--rw domain-searchlist-option! {domain-searchlist-op}?
+       |  |     |  +--rw domain-searchlist* [domain-searchlist-id]
+       |  |     |     +--rw domain-searchlist-id        uint8
+       |  |     |     +--rw domain-search-list-entry    string
+       |  |     +--rw nis-config-option! {nis-config-op}?
+       |  |     |  +--rw nis-server* [nis-serv-id]
+       |  |     |     +--rw nis-serv-id      uint8
+       |  |     |     +--rw nis-serv-addr    inet:ipv6-address
+       |  |     +--rw nis-plus-config-option! {nis-plus-config-op}?
+       |  |     |  +--rw nis-plus-server* [nis-plus-serv-id]
+       |  |     |     +--rw nis-plus-serv-id      uint8
+       |  |     |     +--rw nis-plus-serv-addr    inet:ipv6-address
+       |  |     +--rw nis-domain-name-option! {nis-domain-name-op}?
+       |  |     |  +--rw nis-domain-name?   string
+       |  |     +--rw nis-plus-domain-name-option! {nis-plus-domain-name-op}?
+       |  |     |  +--rw nis-plus-domain-name?   string
+       |  |     +--rw sntp-server-option! {sntp-server-op}?
+       |  |     |  +--rw sntp-server* [sntp-serv-id]
+       |  |     |     +--rw sntp-serv-id      uint8
+       |  |     |     +--rw sntp-serv-addr    inet:ipv6-address
+       |  |     +--rw info-refresh-time-option! {info-refresh-time-op}?
+       |  |     |  +--rw info-refresh-time    yang:timeticks
+       |  |     +--rw client-fqdn-option! {client-fqdn-op}?
+       |  |     |  +--rw server-initiate-update    boolean
+       |  |     |  +--rw client-initiate-update    boolean
+       |  |     |  +--rw modify-name-from-cli      boolean
+       |  |     +--rw posix-timezone-option! {posix-timezone-op}?
+       |  |     |  +--rw tz-posix    string
+       |  |     +--rw tzdb-timezone-option! {tzdb-timezone-op}?
+       |  |     |  +--rw tz-database    string
+       |  |     +--rw ntp-server-option! {ntp-server-op}?
+       |  |     |  +--rw ntp-server* [ntp-serv-id]
+       |  |     |     +--rw ntp-serv-id                    uint8
+       |  |     |     +--rw (ntp-time-source-suboption)?
+       |  |     |        +--:(server-address)
+       |  |     |        |  +--rw ntp-serv-addr-suboption*       inet:ipv6-address
+       |  |     |        +--:(server-multicast-address)
+       |  |     |        |  +--rw ntp-serv-mul-addr-suboption*   inet:ipv6-address
+       |  |     |        +--:(server-fqdn)
+       |  |     |           +--rw ntp-serv-fqdn-suboption*       string
+       |  |     +--rw boot-file-url-option! {boot-file-url-op}?
+       |  |     |  +--rw boot-file* [boot-file-id]
+       |  |     |     +--rw boot-file-id          uint8
+       |  |     |     +--rw suitable-arch-type*   uint16
+       |  |     |     +--rw suitable-net-if*      uint32
+       |  |     |     +--rw boot-file-url         string
+       |  |     +--rw boot-file-param-option! {boot-file-param-op}?
+       |  |     |  +--rw boot-file-paras* [para-id]
+       |  |     |     +--rw para-id      uint8
+       |  |     |     +--rw parameter    string
+       |  |     +--rw aftr-name-option! {aftr-name-op}?
+       |  |     |  +--rw tunnel-endpoint-name    string
+       |  |     +--rw kbr-default-name-option! {kbr-default-name-op}?
+       |  |     |  +--rw default-realm-name    string
+       |  |     +--rw kbr-kdc-option! {kbr-kdc-op}?
+       |  |     |  +--rw kdc-info* [kdc-id]
+       |  |     |     +--rw kdc-id            uint8
+       |  |     |     +--rw priority          uint16
+       |  |     |     +--rw weight            uint16
+       |  |     |     +--rw transport-type    uint8
+       |  |     |     +--rw port-number       uint16
+       |  |     |     +--rw kdc-ipv6-addr     inet:ipv6-address
+       |  |     |     +--rw realm-name        string
+       |  |     +--rw sol-max-rt-option! {sol-max-rt-op}?
+       |  |     |  +--rw sol-max-rt-value    yang:timeticks
+       |  |     +--rw inf-max-rt-option! {inf-max-rt-op}?
+       |  |     |  +--rw inf-max-rt-value    yang:timeticks
+       |  |     +--rw addr-selection-option! {addr-selection-op}?
+       |  |     |  +--rw a-bit-set       boolean
+       |  |     |  +--rw p-bit-set       boolean
+       |  |     |  +--rw policy-table* [policy-id]
+       |  |     |     +--rw policy-id     uint8
+       |  |     |     +--rw label         uint8
+       |  |     |     +--rw precedence    uint8
+       |  |     |     +--rw prefix-len    uint8
+       |  |     |     +--rw prefix        inet:ipv6-prefix
+       |  |     +--rw pcp-server-option! {pcp-server-op}?
+       |  |     |  +--rw pcp-server* [pcp-serv-id]
+       |  |     |     +--rw pcp-serv-id      uint8
+       |  |     |     +--rw pcp-serv-addr    inet:ipv6-address
+       |  |     +--rw s46-rule-option! {s46-rule-op}?
+       |  |     |  +--rw s46-rule* [rule-id]
+       |  |     |     +--rw rule-id           uint8
+       |  |     |     +--rw rule-type         enumeration
+       |  |     |     +--rw prefix4-len       uint8
+       |  |     |     +--rw ipv4-prefix       inet:ipv4-prefix
+       |  |     |     +--rw prefix6-len       uint8
+       |  |     |     +--rw ipv6-prefix       inet:ipv6-prefix
+       |  |     |     +--rw port-parameter
+       |  |     |        +--rw offset      uint8
+       |  |     |        +--rw psid-len    uint8
+       |  |     |        +--rw psid        uint16
+       |  |     +--rw s46-br-option! {s46-br-op}?
+       |  |     |  +--rw br* [br-id]
+       |  |     |     +--rw br-id           uint8
+       |  |     |     +--rw br-ipv6-addr    inet:ipv6-address
+       |  |     +--rw s46-dmr-option! {s46-dmr-op}?
+       |  |     |  +--rw dmr* [dmr-id]
+       |  |     |     +--rw dmr-id             uint8
+       |  |     |     +--rw dmr-prefix-len     uint8
+       |  |     |     +--rw dmr-ipv6-prefix    inet:ipv6-prefix
+       |  |     +--rw s46-v4-v6-binding-option! {s46-v4-v6-binding-op}?
+       |  |     |  +--rw ce* [ce-id]
+       |  |     |     +--rw ce-id               uint8
+       |  |     |     +--rw ipv4-addr           inet:ipv4-address
+       |  |     |     +--rw bind-prefix6-len    uint8
+       |  |     |     +--rw bind-ipv6-prefix    inet:ipv6-prefix
+       |  |     |     +--rw port-parameter
+       |  |     |        +--rw offset      uint8
+       |  |     |        +--rw psid-len    uint8
+       |  |     |        +--rw psid        uint16
+       |  |     +--rw operator-option-ipv6-address! {operator-op-ipv6-address}?
+       |  |     |  +--rw operator-ipv6-addr* [operator-ipv6-addr-id]
+       |  |     |     +--rw operator-ipv6-addr-id    uint8
+       |  |     |     +--rw operator-ipv6-addr       inet:ipv6-address
+       |  |     +--rw operator-option-single-flag! {operator-op-single-flag}?
+       |  |     |  +--rw flag* [flag-id]
+       |  |     |     +--rw flag-id       uint8
+       |  |     |     +--rw flag-value    boolean
+       |  |     +--rw operator-option-ipv6-prefix! {operator-op-ipv6-prefix}?
+       |  |     |  +--rw operator-ipv6-prefix* [operator-ipv6-prefix-id]
+       |  |     |     +--rw operator-ipv6-prefix-id      uint8
+       |  |     |     +--rw operator-ipv6-prefix6-len    uint8
+       |  |     |     +--rw operator-ipv6-prefix         inet:ipv6-prefix
+       |  |     +--rw operator-option-int32! {operator-op-int32}?
+       |  |     |  +--rw int32val* [int32val-id]
+       |  |     |     +--rw int32val-id    uint8
+       |  |     |     +--rw int32val       uint32
+       |  |     +--rw operator-option-int16! {operator-op-int16}?
+       |  |     |  +--rw int16val* [int16val-id]
+       |  |     |     +--rw int16val-id    uint8
+       |  |     |     +--rw int16val       uint16
+       |  |     +--rw operator-option-int8! {operator-op-int8}?
+       |  |     |  +--rw int8val* [int8val-id]
+       |  |     |     +--rw int8val-id    uint8
+       |  |     |     +--rw int8val       uint8
+       |  |     +--rw operator-option-uri! {operator-op-uri}?
+       |  |     |  +--rw uri* [uri-id]
+       |  |     |     +--rw uri-id    uint8
+       |  |     |     +--rw uri       string
+       |  |     +--rw operator-option-textstring! {operator-op-textstring}?
+       |  |     |  +--rw textstring* [textstring-id]
+       |  |     |     +--rw textstring-id    uint8
+       |  |     |     +--rw textstring       string
+       |  |     +--rw operator-option-var-data! {operator-op-var-data}?
+       |  |     |  +--rw int32val* [var-data-id]
+       |  |     |     +--rw var-data-id    uint8
+       |  |     |     +--rw var-data       binary
+       |  |     +--rw operator-option-dns-wire! {operator-op-dns-wire}?
+       |  |        +--rw operator-option-dns-wire* [operator-option-dns-wire-id]
+       |  |           +--rw operator-option-dns-wire-id    uint8
+       |  |           +--rw operator-option-dns-wire       binary
+       |  +--rw network-ranges
+       |  |  +--rw network-range* [network-range-id]
+       |  |     +--rw network-range-id       uint32
+       |  |     +--rw network-description    string
+       |  |     +--rw network-prefix         inet:ipv6-prefix
+       |  |     +--rw inherit-option-set     boolean
+       |  |     +--rw option-set-id?         -> /server/server-config/option-sets/option-set/id
+       |  |     +--rw reserved-addresses
+       |  |     |  +--rw static-binding* [cli-id]
+       |  |     |  |  +--rw cli-id         uint32
+       |  |     |  |  +--rw duid
+       |  |     |  |  |  +--rw type-code?                   uint16
+       |  |     |  |  |  +--rw (duid-type)?
+       |  |     |  |  |     +--:(duid-llt)
+       |  |     |  |  |     |  +--rw duid-llt-hardware-type?      uint16
+       |  |     |  |  |     |  +--rw duid-llt-time?               yang:timeticks
+       |  |     |  |  |     |  +--rw duid-llt-link-layer-addr?    yang:mac-address
+       |  |     |  |  |     +--:(duid-en)
+       |  |     |  |  |     |  +--rw duid-en-enterprise-number?   uint32
+       |  |     |  |  |     |  +--rw duid-en-identifier?          string
+       |  |     |  |  |     +--:(duid-ll)
+       |  |     |  |  |     |  +--rw duid-ll-hardware-type?       uint16
+       |  |     |  |  |     |  +--rw duid-ll-link-layer-addr?     yang:mac-address
+       |  |     |  |  |     +--:(duid-uuid)
+       |  |     |  |  |     |  +--rw uuid?                        yang:uuid
+       |  |     |  |  |     +--:(duid-invalid)
+       |  |     |  |  |        +--rw data?                        binary
+       |  |     |  |  +--rw reserv-addr*   inet:ipv6-address
+       |  |     |  +--rw other-reserv-addr*   inet:ipv6-address
+       |  |     +--rw reserved-prefixes
+       |  |     |  +--rw static-binding* [cli-id]
+       |  |     |  |  +--rw cli-id               uint32
+       |  |     |  |  +--rw duid
+       |  |     |  |  |  +--rw type-code?                   uint16
+       |  |     |  |  |  +--rw (duid-type)?
+       |  |     |  |  |     +--:(duid-llt)
+       |  |     |  |  |     |  +--rw duid-llt-hardware-type?      uint16
+       |  |     |  |  |     |  +--rw duid-llt-time?               yang:timeticks
+       |  |     |  |  |     |  +--rw duid-llt-link-layer-addr?    yang:mac-address
+       |  |     |  |  |     +--:(duid-en)
+       |  |     |  |  |     |  +--rw duid-en-enterprise-number?   uint32
+       |  |     |  |  |     |  +--rw duid-en-identifier?          string
+       |  |     |  |  |     +--:(duid-ll)
+       |  |     |  |  |     |  +--rw duid-ll-hardware-type?       uint16
+       |  |     |  |  |     |  +--rw duid-ll-link-layer-addr?     yang:mac-address
+       |  |     |  |  |     +--:(duid-uuid)
+       |  |     |  |  |     |  +--rw uuid?                        yang:uuid
+       |  |     |  |  |     +--:(duid-invalid)
+       |  |     |  |  |        +--rw data?                        binary
+       |  |     |  |  +--rw reserv-prefix-len    uint8
+       |  |     |  |  +--rw reserv-prefix        inet:ipv6-prefix
+       |  |     |  +--rw exclude-prefix-len     uint8
+       |  |     |  +--rw exclude-prefix         inet:ipv6-prefix
+       |  |     |  +--rw other-reserv-prefix* [reserv-id]
+       |  |     |     +--rw reserv-id     uint32
+       |  |     |     +--rw prefix-len    uint8
+       |  |     |     +--rw prefix        inet:ipv6-prefix
+       |  |     +--rw address-pools
+       |  |     |  +--rw address-pool* [pool-id]
+       |  |     |     +--rw pool-id                          uint32
+       |  |     |     +--rw pool-prefix                      inet:ipv6-prefix
+       |  |     |     +--rw start-address                    inet:ipv6-address-no-zone
+       |  |     |     +--rw end-address                      inet:ipv6-address-no-zone
+       |  |     |     +--rw renew-time                       yang:timeticks
+       |  |     |     +--rw rebind-time                      yang:timeticks
+       |  |     |     +--rw preferred-lifetime               yang:timeticks
+       |  |     |     +--rw valid-lifetime                   yang:timeticks
+       |  |     |     +--rw max-address-utilization-ratio    threshold
+       |  |     |     +--rw inherit-option-set               boolean
+       |  |     |     +--rw option-set-id                    -> /server/server-config/option-sets/option-set/id
+       |  |     +--rw prefix-pools
+       |  |     |  +--rw prefix-pool* [pool-id]
+       |  |     |     +--rw pool-id                         uint32
+       |  |     |     +--rw prefix                          inet:ipv6-prefix
+       |  |     |     +--rw prefix-length                   uint8
+       |  |     |     +--rw renew-time                      yang:timeticks
+       |  |     |     +--rw rebind-time                     yang:timeticks
+       |  |     |     +--rw preferred-lifetime              yang:timeticks
+       |  |     |     +--rw valid-lifetime                  yang:timeticks
+       |  |     |     +--rw max-prefix-utilization-ratio    threshold
+       |  |     |     +--rw inherit-option-set              boolean
+       |  |     |     +--rw option-set-id?                  -> /server/server-config/option-sets/option-set/id
+       |  |     +--rw hosts
+       |  |        +--rw host* [cli-id]
+       |  |           +--rw cli-id                  uint32
+       |  |           +--rw duid
+       |  |           |  +--rw type-code?                   uint16
+       |  |           |  +--rw (duid-type)?
+       |  |           |     +--:(duid-llt)
+       |  |           |     |  +--rw duid-llt-hardware-type?      uint16
+       |  |           |     |  +--rw duid-llt-time?               yang:timeticks
+       |  |           |     |  +--rw duid-llt-link-layer-addr?    yang:mac-address
+       |  |           |     +--:(duid-en)
+       |  |           |     |  +--rw duid-en-enterprise-number?   uint32
+       |  |           |     |  +--rw duid-en-identifier?          string
+       |  |           |     +--:(duid-ll)
+       |  |           |     |  +--rw duid-ll-hardware-type?       uint16
+       |  |           |     |  +--rw duid-ll-link-layer-addr?     yang:mac-address
+       |  |           |     +--:(duid-uuid)
+       |  |           |     |  +--rw uuid?                        yang:uuid
+       |  |           |     +--:(duid-invalid)
+       |  |           |        +--rw data?                        binary
+       |  |           +--rw inherit-option-set      boolean
+       |  |           +--rw option-set-id?          -> /server/server-config/option-sets/option-set/id
+       |  |           +--rw nis-domain-name?        string
+       |  |           +--rw nis-plus-domain-name?   string
+       |  +--rw relay-opaque-paras
+       |  |  +--rw relays* [relay-name]
+       |  |     +--rw relay-name        string
+       |  |     +--rw interface-info* [if-name]
+       |  |     |  +--rw if-name         string
+       |  |     |  +--rw interface-id    string
+       |  |     +--rw subscribers* [subscriber]
+       |  |     |  +--rw subscriber       uint32
+       |  |     |  +--rw subscriber-id    string
+       |  |     +--rw remote-host* [ent-num]
+       |  |        +--rw ent-num      uint32
+       |  |        +--rw remote-id    string
+       |  +--rw rsoo-enabled-options
+       |     +--rw rsoo-enabled-option* [option-code]
+       |        +--rw option-code    uint16
+       |        +--rw description    string
+       +--ro server-state
+          +--ro network-ranges
+          |  +--ro network-range* [network-range-id]
+          |     +--ro network-range-id               uint32
+          |     +--ro address-pools
+          |     |  +--ro address-pool* [pool-id]
+          |     |  |  +--ro pool-id                      uint32
+          |     |  |  +--ro total-ipv6-count             uint64
+          |     |  |  +--ro used-ipv6-count              uint64
+          |     |  |  +--ro address-utilization-ratio    uint16
+          |     |  +--ro binding-info* [cli-id]
+          |     |     +--ro cli-id    uint32
+          |     |     +--ro duid
+          |     |     |  +--ro type-code?                   uint16
+          |     |     |  +--ro (duid-type)?
+          |     |     |     +--:(duid-llt)
+          |     |     |     |  +--ro duid-llt-hardware-type?      uint16
+          |     |     |     |  +--ro duid-llt-time?               yang:timeticks
+          |     |     |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+          |     |     |     +--:(duid-en)
+          |     |     |     |  +--ro duid-en-enterprise-number?   uint32
+          |     |     |     |  +--ro duid-en-identifier?          string
+          |     |     |     +--:(duid-ll)
+          |     |     |     |  +--ro duid-ll-hardware-type?       uint16
+          |     |     |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+          |     |     |     +--:(duid-uuid)
+          |     |     |     |  +--ro uuid?                        yang:uuid
+          |     |     |     +--:(duid-invalid)
+          |     |     |        +--ro data?                        binary
+          |     |     +--ro cli-ia* [iaid]
+          |     |        +--ro ia-type     string
+          |     |        +--ro iaid        uint32
+          |     |        +--ro cli-addr*   inet:ipv6-address
+          |     |        +--ro pool-id     uint32
+          |     +--ro prefix-pools
+          |     |  +--ro prefix-pool* [pool-id]
+          |     |  |  +--ro pool-id                     uint32
+          |     |  |  +--ro prefix-utilization-ratio    uint16
+          |     |  +--ro binding-info* [cli-id]
+          |     |     +--ro cli-id      uint32
+          |     |     +--ro duid
+          |     |     |  +--ro type-code?                   uint16
+          |     |     |  +--ro (duid-type)?
+          |     |     |     +--:(duid-llt)
+          |     |     |     |  +--ro duid-llt-hardware-type?      uint16
+          |     |     |     |  +--ro duid-llt-time?               yang:timeticks
+          |     |     |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+          |     |     |     +--:(duid-en)
+          |     |     |     |  +--ro duid-en-enterprise-number?   uint32
+          |     |     |     |  +--ro duid-en-identifier?          string
+          |     |     |     +--:(duid-ll)
+          |     |     |     |  +--ro duid-ll-hardware-type?       uint16
+          |     |     |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+          |     |     |     +--:(duid-uuid)
+          |     |     |     |  +--ro uuid?                        yang:uuid
+          |     |     |     +--:(duid-invalid)
+          |     |     |        +--ro data?                        binary
+          |     |     +--ro cli-iapd* [iaid]
+          |     |        +--ro iaid              uint32
+          |     |        +--ro cli-prefix*       inet:ipv6-prefix
+          |     |        +--ro cli-prefix-len*   uint8
+          |     |        +--ro pool-id           uint32
+          |     +--ro address-prefix-assign-param* [cli-id]
+          |        +--ro cli-id                      uint32
+          |        +--ro source-ipv6-addr?           inet:ipv6-address
+          |        +--ro duid
+          |        |  +--ro type-code?                   uint16
+          |        |  +--ro (duid-type)?
+          |        |     +--:(duid-llt)
+          |        |     |  +--ro duid-llt-hardware-type?      uint16
+          |        |     |  +--ro duid-llt-time?               yang:timeticks
+          |        |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+          |        |     +--:(duid-en)
+          |        |     |  +--ro duid-en-enterprise-number?   uint32
+          |        |     |  +--ro duid-en-identifier?          string
+          |        |     +--:(duid-ll)
+          |        |     |  +--ro duid-ll-hardware-type?       uint16
+          |        |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+          |        |     +--:(duid-uuid)
+          |        |     |  +--ro uuid?                        yang:uuid
+          |        |     +--:(duid-invalid)
+          |        |        +--ro data?                        binary
+          |        +--ro iaid*                       uint32
+          |        +--ro preferred-addr*             inet:ipv6-address
+          |        +--ro preferred-prefix-len*       uint8
+          |        +--ro client-fqdn?                string
+          |        +--ro client-link-layer-addr?     uint16
+          |        +--ro client-enterprise-number?   uint32
+          |        +--ro client-sys-archi-type*      uint16
+          +--ro packet-stats
+             +--ro solicit-count          uint32
+             +--ro request-count          uint32
+             +--ro renew-count            uint32
+             +--ro rebind-count           uint32
+             +--ro decline-count          uint32
+             +--ro release-count          uint32
+             +--ro info-req-count         uint32
+             +--ro advertise-count        uint32
+             +--ro confirm-count          uint32
+             +--ro reply-count            uint32
+             +--ro reconfigure-count      uint32
+             +--ro relay-forward-count    uint32
+             +--ro relay-reply-count      uint32
+
+  notifications:
+    +---n notifications
+       +--ro dhcpv6-server-event
+          +--ro pool-running-out
+          |  +--ro max-address-utilization-ratio    uint16
+          |  +--ro address-utilization-ratio        uint16
+          |  +--ro max-prefix-utilization-ratio     uint16
+          |  +--ro prefix-utilization-ratio         uint16
+          |  +--ro duid
+          |  |  +--ro type-code?                   uint16
+          |  |  +--ro (duid-type)?
+          |  |     +--:(duid-llt)
+          |  |     |  +--ro duid-llt-hardware-type?      uint16
+          |  |     |  +--ro duid-llt-time?               yang:timeticks
+          |  |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+          |  |     +--:(duid-en)
+          |  |     |  +--ro duid-en-enterprise-number?   uint32
+          |  |     |  +--ro duid-en-identifier?          string
+          |  |     +--:(duid-ll)
+          |  |     |  +--ro duid-ll-hardware-type?       uint16
+          |  |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+          |  |     +--:(duid-uuid)
+          |  |     |  +--ro uuid?                        yang:uuid
+          |  |     +--:(duid-invalid)
+          |  |        +--ro data?                        binary
+          |  +--ro serv-name?                       string
+          |  +--ro pool-name                        string
+          +--ro invalid-client-detected
+             +--ro duid
+             |  +--ro type-code?                   uint16
+             |  +--ro (duid-type)?
+             |     +--:(duid-llt)
+             |     |  +--ro duid-llt-hardware-type?      uint16
+             |     |  +--ro duid-llt-time?               yang:timeticks
+             |     |  +--ro duid-llt-link-layer-addr?    yang:mac-address
+             |     +--:(duid-en)
+             |     |  +--ro duid-en-enterprise-number?   uint32
+             |     |  +--ro duid-en-identifier?          string
+             |     +--:(duid-ll)
+             |     |  +--ro duid-ll-hardware-type?       uint16
+             |     |  +--ro duid-ll-link-layer-addr?     yang:mac-address
+             |     +--:(duid-uuid)
+             |     |  +--ro uuid?                        yang:uuid
+             |     +--:(duid-invalid)
+             |        +--ro data?                        binary
+             +--ro description?   string


### PR DESCRIPTION
Hi, 
This is the version 05. The mainly changes are:
  - Added a ‘duid-invalid’ type as discussed in the mailing list.
  - Re-worked address/pool utilization. Now ‘max-address/prefix-utilization-ratio’ is a configurable threshold value, and ‘address/prefix-utilization-ratio’ is under the state tree indicating current utilization ratio. These are used by notifications.
 - Added a list ‘address-prefix-assign-param’ node under state data of server. This might be a way to define the logic for the server to assign addresses/prefixes.
  - Further revised and modeled some options. But there is still much to do.
  - Added three files 'tree-server', 'tree-relay' and 'tree-client'. Maybe it is a better way for others to review than the tedious code.